### PR TITLE
SPA catch-all for URL routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,16 @@ app.get('/api/health', (req, res) => {
 // Game routes
 app.use('/api', gamesRouter);
 
+// SPA catch-all: serve index.html for non-API, non-static paths
+// This allows path-based URLs (/replay, /games) to load the app,
+// which then redirects to the hash equivalent (/#/replay, /#/games)
+if (process.env.CLIENT_DIR) {
+  app.get('*', (req, res, next) => {
+    if (req.path.startsWith('/api')) return next();
+    res.sendFile(path.resolve(process.env.CLIENT_DIR, 'index.html'));
+  });
+}
+
 // Error handling
 app.use((err, req, res, next) => {
   console.error('Unhandled error:', err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.00.0000",
+  "version": "1.00.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.00.0001",
+  "version": "1.01.0000",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add SPA catch-all route after API routes to serve `index.html` for non-API, non-static paths
- Enables path-based URLs (`/replay`, `/games`) to load the client app, which redirects to hash equivalents

## Changes
- **Modified:** `index.js` — add `app.get('*', ...)` catch-all when `CLIENT_DIR` is set

## Test plan
- [x] Path-based URLs serve index.html and redirect to hash routes
- [x] API routes still work normally
- [x] Static files still served correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)