### PR TITLE
User Accounts: Auth, Profiles, Ratings, Friends

### DIFF
--- a/db.js
+++ b/db.js
@@ -178,12 +178,15 @@ function getDb() {
 
 // --- Query helpers ---
 
-function createGame(metadata) {
+function createGame(metadata, userId) {
+  const whiteUserId = (!metadata.white.isAI && userId) ? userId : null;
+  const blackUserId = (!metadata.black.isAI && userId) ? userId : null;
   const stmt = db.prepare(`
     INSERT INTO games (start_time, game_type, time_control, starting_fen,
       white_name, white_is_ai, white_elo, white_engine,
-      black_name, black_is_ai, black_elo, black_engine)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      black_name, black_is_ai, black_elo, black_engine,
+      white_user_id, black_user_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const info = stmt.run(
     Date.now(),
@@ -197,7 +200,9 @@ function createGame(metadata) {
     metadata.black.name,
     metadata.black.isAI ? 1 : 0,
     metadata.black.elo ?? null,
-    metadata.black.engineId ?? null
+    metadata.black.engineId ?? null,
+    whiteUserId,
+    blackUserId
   );
   return info.lastInsertRowid;
 }

--- a/db.js
+++ b/db.js
@@ -525,13 +525,13 @@ function listGamesByUser(userId, { limit = 15, offset = 0, category, result, opp
   const params = [userId, userId];
 
   if (result === 'win') {
-    where += ` AND ((g.white_user_id = ? AND g.result = 'white') OR (g.black_user_id = ? AND g.result = 'black'))`;
+    where += ` AND ((g.white_user_id = ? AND g.result IN ('white', '1-0')) OR (g.black_user_id = ? AND g.result IN ('black', '0-1')))`;
     params.push(userId, userId);
   } else if (result === 'loss') {
-    where += ` AND ((g.white_user_id = ? AND g.result = 'black') OR (g.black_user_id = ? AND g.result = 'white'))`;
+    where += ` AND ((g.white_user_id = ? AND g.result IN ('black', '0-1')) OR (g.black_user_id = ? AND g.result IN ('white', '1-0')))`;
     params.push(userId, userId);
   } else if (result === 'draw') {
-    where += ` AND g.result = 'draw'`;
+    where += ` AND g.result IN ('draw', '1/2-1/2')`;
   } else if (result === 'abandoned') {
     where += ` AND g.result = 'abandoned'`;
   }

--- a/db.js
+++ b/db.js
@@ -534,6 +534,8 @@ function listGamesByUser(userId, { limit = 15, offset = 0, category, result, opp
     where += ` AND g.result IN ('draw', '1/2-1/2')`;
   } else if (result === 'abandoned') {
     where += ` AND g.result = 'abandoned'`;
+  } else if (result === 'ongoing') {
+    where += ` AND g.result IS NULL`;
   }
 
   if (gameType && gameType !== 'all') {

--- a/db.js
+++ b/db.js
@@ -67,6 +67,103 @@ function initDb() {
     // Index may already exist; ignore
   }
 
+  // --- User accounts tables ---
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      wp_user_id      INTEGER UNIQUE NOT NULL,
+      username        TEXT NOT NULL UNIQUE,
+      display_name    TEXT NOT NULL,
+      avatar_url      TEXT,
+      bio             TEXT DEFAULT '',
+      profile_public  INTEGER NOT NULL DEFAULT 1,
+      games_public    INTEGER NOT NULL DEFAULT 1,
+      created_at      INTEGER NOT NULL,
+      last_seen_at    INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_users_wp_id ON users(wp_user_id);
+    CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+
+    CREATE TABLE IF NOT EXISTS ratings (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      category        TEXT NOT NULL,
+      rating          REAL NOT NULL DEFAULT 1500.0,
+      rd              REAL NOT NULL DEFAULT 350.0,
+      volatility      REAL NOT NULL DEFAULT 0.06,
+      games_played    INTEGER NOT NULL DEFAULT 0,
+      wins            INTEGER NOT NULL DEFAULT 0,
+      losses          INTEGER NOT NULL DEFAULT 0,
+      draws           INTEGER NOT NULL DEFAULT 0,
+      UNIQUE(user_id, category)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_ratings_user ON ratings(user_id);
+
+    CREATE TABLE IF NOT EXISTS rating_history (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      category        TEXT NOT NULL,
+      game_id         INTEGER REFERENCES games(id) ON DELETE SET NULL,
+      old_rating      REAL NOT NULL,
+      new_rating      REAL NOT NULL,
+      old_rd          REAL NOT NULL,
+      new_rd          REAL NOT NULL,
+      opponent_rating REAL,
+      result          TEXT NOT NULL,
+      timestamp       INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_rating_history_user ON rating_history(user_id, category);
+    CREATE INDEX IF NOT EXISTS idx_rating_history_timestamp ON rating_history(timestamp);
+
+    CREATE TABLE IF NOT EXISTS friendships (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      friend_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      status          TEXT NOT NULL DEFAULT 'pending',
+      created_at      INTEGER NOT NULL,
+      updated_at      INTEGER NOT NULL,
+      UNIQUE(user_id, friend_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_friendships_user ON friendships(user_id);
+    CREATE INDEX IF NOT EXISTS idx_friendships_friend ON friendships(friend_id);
+
+    CREATE TABLE IF NOT EXISTS user_settings (
+      user_id         INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      settings_json   TEXT NOT NULL DEFAULT '{}'
+    );
+  `);
+
+  // Migration: add user account columns to games table
+  try {
+    db.exec(`ALTER TABLE games ADD COLUMN white_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL`);
+  } catch (e) { /* column already exists */ }
+  try {
+    db.exec(`ALTER TABLE games ADD COLUMN black_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL`);
+  } catch (e) { /* column already exists */ }
+  try {
+    db.exec(`ALTER TABLE games ADD COLUMN white_rating_before REAL`);
+  } catch (e) { /* column already exists */ }
+  try {
+    db.exec(`ALTER TABLE games ADD COLUMN black_rating_before REAL`);
+  } catch (e) { /* column already exists */ }
+  try {
+    db.exec(`ALTER TABLE games ADD COLUMN white_rating_after REAL`);
+  } catch (e) { /* column already exists */ }
+  try {
+    db.exec(`ALTER TABLE games ADD COLUMN black_rating_after REAL`);
+  } catch (e) { /* column already exists */ }
+  try {
+    db.exec(`ALTER TABLE games ADD COLUMN rated INTEGER NOT NULL DEFAULT 0`);
+  } catch (e) { /* column already exists */ }
+
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_games_white_user ON games(white_user_id)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_games_black_user ON games(black_user_id)`);
+
   return db;
 }
 
@@ -217,6 +314,259 @@ function deleteGame(gameId) {
   db.prepare('DELETE FROM games WHERE id = ?').run(gameId);
 }
 
+// --- User helpers ---
+
+function upsertUser(wpUserId, username, displayName, avatarUrl) {
+  const now = Date.now();
+  const existing = db.prepare('SELECT id FROM users WHERE wp_user_id = ?').get(wpUserId);
+  if (existing) {
+    db.prepare(`
+      UPDATE users SET username = ?, display_name = ?, avatar_url = ?, last_seen_at = ?
+      WHERE wp_user_id = ?
+    `).run(username, displayName, avatarUrl, now, wpUserId);
+    return db.prepare('SELECT * FROM users WHERE wp_user_id = ?').get(wpUserId);
+  }
+  db.prepare(`
+    INSERT INTO users (wp_user_id, username, display_name, avatar_url, created_at, last_seen_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(wpUserId, username, displayName, avatarUrl, now, now);
+  return db.prepare('SELECT * FROM users WHERE wp_user_id = ?').get(wpUserId);
+}
+
+function getUserByWpId(wpUserId) {
+  return db.prepare('SELECT * FROM users WHERE wp_user_id = ?').get(wpUserId);
+}
+
+function getUserByUsername(username) {
+  return db.prepare('SELECT * FROM users WHERE username = ?').get(username);
+}
+
+function getUserById(userId) {
+  return db.prepare('SELECT * FROM users WHERE id = ?').get(userId);
+}
+
+function updateUser(userId, fields) {
+  const allowed = ['display_name', 'bio', 'avatar_url', 'profile_public', 'games_public'];
+  const sets = [];
+  const values = [];
+  for (const [key, val] of Object.entries(fields)) {
+    if (allowed.includes(key)) {
+      sets.push(`${key} = ?`);
+      values.push(val);
+    }
+  }
+  if (sets.length === 0) return;
+  values.push(userId);
+  db.prepare(`UPDATE users SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+}
+
+function formatUser(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    wpUserId: row.wp_user_id,
+    username: row.username,
+    displayName: row.display_name,
+    avatarUrl: row.avatar_url,
+    bio: row.bio,
+    profilePublic: !!row.profile_public,
+    gamesPublic: !!row.games_public,
+    createdAt: row.created_at,
+    lastSeenAt: row.last_seen_at
+  };
+}
+
+// --- Rating helpers ---
+
+function getRatings(userId) {
+  const rows = db.prepare('SELECT * FROM ratings WHERE user_id = ?').all(userId);
+  const result = {};
+  for (const row of rows) {
+    result[row.category] = {
+      rating: row.rating,
+      rd: row.rd,
+      volatility: row.volatility,
+      gamesPlayed: row.games_played,
+      wins: row.wins,
+      losses: row.losses,
+      draws: row.draws
+    };
+  }
+  return result;
+}
+
+function ensureRating(userId, category) {
+  db.prepare(`
+    INSERT OR IGNORE INTO ratings (user_id, category, rating, rd, volatility, games_played, wins, losses, draws)
+    VALUES (?, ?, 1500.0, 350.0, 0.06, 0, 0, 0, 0)
+  `).run(userId, category);
+  return db.prepare('SELECT * FROM ratings WHERE user_id = ? AND category = ?').get(userId, category);
+}
+
+function updateRatingRecord(userId, category, rating, rd, volatility, resultType) {
+  const winInc = resultType === 'win' ? 1 : 0;
+  const lossInc = resultType === 'loss' ? 1 : 0;
+  const drawInc = resultType === 'draw' ? 1 : 0;
+  db.prepare(`
+    UPDATE ratings SET rating = ?, rd = ?, volatility = ?,
+      games_played = games_played + 1,
+      wins = wins + ?, losses = losses + ?, draws = draws + ?
+    WHERE user_id = ? AND category = ?
+  `).run(rating, rd, volatility, winInc, lossInc, drawInc, userId, category);
+}
+
+function addRatingHistory(userId, category, gameId, oldRating, newRating, oldRd, newRd, opponentRating, result) {
+  db.prepare(`
+    INSERT INTO rating_history (user_id, category, game_id, old_rating, new_rating, old_rd, new_rd, opponent_rating, result, timestamp)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(userId, category, gameId, oldRating, newRating, oldRd, newRd, opponentRating, result, Date.now());
+}
+
+function getRatingHistory(userId, category, limit = 50, offset = 0) {
+  return db.prepare(`
+    SELECT * FROM rating_history
+    WHERE user_id = ? AND category = ?
+    ORDER BY timestamp DESC
+    LIMIT ? OFFSET ?
+  `).all(userId, category, limit, offset);
+}
+
+// --- Friendship helpers ---
+
+function createFriendship(userId, friendId) {
+  const now = Date.now();
+  db.prepare(`
+    INSERT INTO friendships (user_id, friend_id, status, created_at, updated_at)
+    VALUES (?, ?, 'pending', ?, ?)
+  `).run(userId, friendId, now, now);
+}
+
+function respondFriendship(friendshipId, status) {
+  db.prepare(`
+    UPDATE friendships SET status = ?, updated_at = ? WHERE id = ?
+  `).run(status, Date.now(), friendshipId);
+}
+
+function getFriendships(userId) {
+  const friends = db.prepare(`
+    SELECT f.*, u.username, u.display_name, u.avatar_url
+    FROM friendships f
+    JOIN users u ON (CASE WHEN f.user_id = ? THEN f.friend_id ELSE f.user_id END) = u.id
+    WHERE (f.user_id = ? OR f.friend_id = ?) AND f.status = 'accepted'
+  `).all(userId, userId, userId);
+
+  const pendingIncoming = db.prepare(`
+    SELECT f.*, u.username, u.display_name, u.avatar_url
+    FROM friendships f
+    JOIN users u ON f.user_id = u.id
+    WHERE f.friend_id = ? AND f.status = 'pending'
+  `).all(userId);
+
+  const pendingOutgoing = db.prepare(`
+    SELECT f.*, u.username, u.display_name, u.avatar_url
+    FROM friendships f
+    JOIN users u ON f.friend_id = u.id
+    WHERE f.user_id = ? AND f.status = 'pending'
+  `).all(userId);
+
+  return { friends, pendingIncoming, pendingOutgoing };
+}
+
+function getFriendship(userId, friendId) {
+  return db.prepare(`
+    SELECT * FROM friendships
+    WHERE (user_id = ? AND friend_id = ?) OR (user_id = ? AND friend_id = ?)
+  `).get(userId, friendId, friendId, userId);
+}
+
+function removeFriendship(userId, friendId) {
+  db.prepare(`
+    DELETE FROM friendships
+    WHERE (user_id = ? AND friend_id = ?) OR (user_id = ? AND friend_id = ?)
+  `).run(userId, friendId, friendId, userId);
+}
+
+// --- Settings helpers ---
+
+function getSettings(userId) {
+  const row = db.prepare('SELECT settings_json FROM user_settings WHERE user_id = ?').get(userId);
+  if (!row) return {};
+  try {
+    return JSON.parse(row.settings_json);
+  } catch (e) {
+    return {};
+  }
+}
+
+function updateSettings(userId, settings) {
+  const current = getSettings(userId);
+  const merged = { ...current, ...settings };
+  const json = JSON.stringify(merged);
+  db.prepare(`
+    INSERT INTO user_settings (user_id, settings_json) VALUES (?, ?)
+    ON CONFLICT(user_id) DO UPDATE SET settings_json = ?
+  `).run(userId, json, json);
+}
+
+// --- Game queries by user ---
+
+function listGamesByUser(userId, { limit = 15, offset = 0, category, result, opponent } = {}) {
+  let where = '(g.white_user_id = ? OR g.black_user_id = ?)';
+  const params = [userId, userId];
+
+  if (result === 'win') {
+    where += ` AND ((g.white_user_id = ? AND g.result = '1-0') OR (g.black_user_id = ? AND g.result = '0-1'))`;
+    params.push(userId, userId);
+  } else if (result === 'loss') {
+    where += ` AND ((g.white_user_id = ? AND g.result = '0-1') OR (g.black_user_id = ? AND g.result = '1-0'))`;
+    params.push(userId, userId);
+  } else if (result === 'draw') {
+    where += ` AND g.result = '1/2-1/2'`;
+  }
+
+  if (opponent) {
+    const oppUser = getUserByUsername(opponent);
+    if (oppUser) {
+      where += ' AND (g.white_user_id = ? OR g.black_user_id = ?)';
+      params.push(oppUser.id, oppUser.id);
+    }
+  }
+
+  const countParams = [...params];
+  const { total } = db.prepare(`SELECT COUNT(*) as total FROM games g WHERE ${where}`).get(...countParams);
+
+  const rows = db.prepare(`
+    SELECT g.*, (SELECT COUNT(*) FROM moves m WHERE m.game_id = g.id) as move_count
+    FROM games g WHERE ${where}
+    ORDER BY g.start_time DESC LIMIT ? OFFSET ?
+  `).all(...params, limit, offset);
+
+  const games = rows.map(row => ({
+    id: row.id,
+    startTime: row.start_time,
+    endTime: row.end_time,
+    gameType: row.game_type,
+    timeControl: row.time_control,
+    white: { name: row.white_name, isAI: !!row.white_is_ai, elo: row.white_elo, engineId: row.white_engine, userId: row.white_user_id },
+    black: { name: row.black_name, isAI: !!row.black_is_ai, elo: row.black_elo, engineId: row.black_engine, userId: row.black_user_id },
+    result: row.result,
+    resultReason: row.result_reason,
+    rated: !!row.rated,
+    moveCount: row.move_count
+  }));
+
+  return { games, total };
+}
+
+function claimGame(gameId, side, userId) {
+  const column = side === 'white' ? 'white_user_id' : 'black_user_id';
+  const game = db.prepare('SELECT * FROM games WHERE id = ?').get(gameId);
+  if (!game) return false;
+  if (game[column] !== null) return false;
+  db.prepare(`UPDATE games SET ${column} = ? WHERE id = ?`).run(userId, gameId);
+  return true;
+}
+
 module.exports = {
   initDb,
   getDb,
@@ -227,5 +577,30 @@ module.exports = {
   getGame,
   listGames,
   listAllGames,
-  deleteGame
+  deleteGame,
+  // User helpers
+  upsertUser,
+  getUserByWpId,
+  getUserByUsername,
+  getUserById,
+  updateUser,
+  formatUser,
+  // Rating helpers
+  getRatings,
+  ensureRating,
+  updateRatingRecord,
+  addRatingHistory,
+  getRatingHistory,
+  // Friendship helpers
+  createFriendship,
+  respondFriendship,
+  getFriendships,
+  getFriendship,
+  removeFriendship,
+  // Settings helpers
+  getSettings,
+  updateSettings,
+  // Game by user helpers
+  listGamesByUser,
+  claimGame
 };

--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@ const express = require('express');
 const path = require('path');
 const { initDb } = require('./db');
 const gamesRouter = require('./routes/games');
+const authRouter = require('./routes/auth');
+const usersRouter = require('./routes/users');
+const friendsRouter = require('./routes/friends');
+const settingsRouter = require('./routes/settings');
+const gameHistoryRouter = require('./routes/game-history');
 const { version } = require('./package.json');
 
 // Initialize database
@@ -30,6 +35,13 @@ app.get('/api/health', (req, res) => {
 
 // Game routes
 app.use('/api', gamesRouter);
+
+// User account routes
+app.use('/api/auth', authRouter);
+app.use('/api', usersRouter);
+app.use('/api', friendsRouter);
+app.use('/api', settingsRouter);
+app.use('/api', gameHistoryRouter);
 
 // SPA catch-all: serve index.html for non-API, non-static paths
 // This allows path-based URLs (/replay, /games) to load the app,

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,45 @@
+const jwt = require('jsonwebtoken');
+const { getUserByWpId } = require('../db');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-in-production';
+
+// Required authentication — returns 401 if no valid token
+function requireAuth(req, res, next) {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  const token = header.slice(7);
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    const wpUserId = decoded.data && decoded.data.user ? decoded.data.user.id : decoded.sub;
+    const user = getUserByWpId(wpUserId);
+    if (!user) {
+      return res.status(401).json({ error: 'User not found' });
+    }
+    req.user = user;
+    next();
+  } catch (e) {
+    return res.status(401).json({ error: 'Invalid or expired token' });
+  }
+}
+
+// Optional authentication — attaches user if token present, continues either way
+function optionalAuth(req, res, next) {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) {
+    req.user = null;
+    return next();
+  }
+  const token = header.slice(7);
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    const wpUserId = decoded.data && decoded.data.user ? decoded.data.user.id : decoded.sub;
+    req.user = getUserByWpId(wpUserId);
+  } catch (e) {
+    req.user = null;
+  }
+  next();
+}
+
+module.exports = { requireAuth, optionalAuth, JWT_SECRET };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "chess-api",
-  "version": "1.0.0001",
+  "version": "1.02.0000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-api",
-      "version": "1.0.0001",
+      "version": "1.02.0000",
       "dependencies": {
         "better-sqlite3": "^11.0.0",
-        "express": "^4.21.0"
+        "express": "^4.21.0",
+        "jsonwebtoken": "^9.0.3"
       }
     },
     "node_modules/accepts": {
@@ -121,6 +122,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -260,6 +266,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -566,6 +580,86 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "chess-api",
-  "version": "1.02.0000",
+  "version": "1.02.0003",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-api",
-      "version": "1.02.0000",
+      "version": "1.02.0003",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.0.0",
         "express": "^4.21.0",
         "jsonwebtoken": "^9.0.3"
@@ -48,6 +49,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/better-sqlite3": {
       "version": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.02.0000",
+  "version": "1.02.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^11.0.0",
-    "express": "^4.21.0"
+    "express": "^4.21.0",
+    "jsonwebtoken": "^9.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.02.0005",
+  "version": "1.02.0006",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.02.0007",
+  "version": "1.02.0008",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.02.0001",
+  "version": "1.02.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.02.0006",
+  "version": "1.02.0007",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.02.0004",
+  "version": "1.02.0005",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "chess-api",
-  "version": "1.02.0003",
+  "version": "1.02.0004",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {
     "start": "node index.js"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "better-sqlite3": "^11.0.0",
     "express": "^4.21.0",
     "jsonwebtoken": "^9.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.02.0002",
+  "version": "1.02.0003",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rating.js
+++ b/rating.js
@@ -1,0 +1,171 @@
+// Glicko-2 Rating System
+// Reference: http://www.glicko.net/glicko/glicko2.pdf
+
+const TAU = 0.5;              // System volatility constant
+const INITIAL_RATING = 1500;
+const INITIAL_RD = 350;
+const INITIAL_VOL = 0.06;
+const CONVERGENCE_TOL = 0.000001;
+const RATING_FLOOR = 100;
+const PROVISIONAL_THRESHOLD = 15; // Games before rating is no longer provisional
+
+// Scale factor between Glicko and Glicko-2
+const GLICKO2_SCALE = 173.7178;
+
+// Time control classification (FIDE formula: minutes + 40 * increment / 60)
+function classifyTimeControl(timeControlStr) {
+  if (!timeControlStr || timeControlStr === 'none') return null;
+
+  // Parse "M+S" format (e.g., "5+3", "10+0")
+  const match = timeControlStr.match(/^(\d+)\+(\d+)$/);
+  if (!match) {
+    // Try named formats
+    const lower = timeControlStr.toLowerCase();
+    if (lower.includes('bullet')) return 'bullet';
+    if (lower.includes('blitz')) return 'blitz';
+    if (lower.includes('rapid')) return 'rapid';
+    if (lower.includes('classical') || lower.includes('classic')) return 'classical';
+    return null;
+  }
+
+  const minutes = parseInt(match[1], 10);
+  const increment = parseInt(match[2], 10);
+  const estimatedTotal = minutes + (40 * increment / 60);
+
+  if (estimatedTotal < 3) return 'bullet';
+  if (estimatedTotal < 10) return 'blitz';
+  if (estimatedTotal < 30) return 'rapid';
+  return 'classical';
+}
+
+// Convert Glicko rating to Glicko-2 scale
+function toGlicko2(rating) {
+  return (rating - 1500) / GLICKO2_SCALE;
+}
+
+// Convert Glicko-2 rating back to Glicko scale
+function fromGlicko2(mu) {
+  return mu * GLICKO2_SCALE + 1500;
+}
+
+// Convert RD to Glicko-2 scale
+function rdToGlicko2(rd) {
+  return rd / GLICKO2_SCALE;
+}
+
+// Convert RD back from Glicko-2 scale
+function rdFromGlicko2(phi) {
+  return phi * GLICKO2_SCALE;
+}
+
+// g(phi) function — reduces the impact of games against opponents with high RD
+function g(phi) {
+  return 1 / Math.sqrt(1 + 3 * phi * phi / (Math.PI * Math.PI));
+}
+
+// E(mu, mu_j, phi_j) — expected score
+function E(mu, muJ, phiJ) {
+  return 1 / (1 + Math.exp(-g(phiJ) * (mu - muJ)));
+}
+
+// Core Glicko-2 rating update for a single game
+// score: 1 = win, 0.5 = draw, 0 = loss
+function updateRating(playerRating, playerRD, playerVol, opponentRating, opponentRD, score) {
+  // Step 1: Convert to Glicko-2 scale
+  const mu = toGlicko2(playerRating);
+  const phi = rdToGlicko2(playerRD);
+  const sigma = playerVol;
+  const muJ = toGlicko2(opponentRating);
+  const phiJ = rdToGlicko2(opponentRD);
+
+  // Step 2: Compute estimated variance v
+  const gPhiJ = g(phiJ);
+  const eVal = E(mu, muJ, phiJ);
+  const v = 1 / (gPhiJ * gPhiJ * eVal * (1 - eVal));
+
+  // Step 3: Compute estimated improvement delta
+  const delta = v * gPhiJ * (score - eVal);
+
+  // Step 4: Compute new volatility sigma' using Illinois algorithm
+  const a = Math.log(sigma * sigma);
+  const phiSq = phi * phi;
+  const deltaSq = delta * delta;
+
+  function f(x) {
+    const ex = Math.exp(x);
+    const num1 = ex * (deltaSq - phiSq - v - ex);
+    const den1 = 2 * (phiSq + v + ex) * (phiSq + v + ex);
+    const num2 = x - a;
+    const den2 = TAU * TAU;
+    return num1 / den1 - num2 / den2;
+  }
+
+  // Find bounds A and B
+  let A = a;
+  let B;
+  if (deltaSq > phiSq + v) {
+    B = Math.log(deltaSq - phiSq - v);
+  } else {
+    let k = 1;
+    while (f(a - k * TAU) < 0) {
+      k++;
+    }
+    B = a - k * TAU;
+  }
+
+  // Illinois algorithm to find root
+  let fA = f(A);
+  let fB = f(B);
+  while (Math.abs(B - A) > CONVERGENCE_TOL) {
+    const C = A + (A - B) * fA / (fB - fA);
+    const fC = f(C);
+    if (fC * fB <= 0) {
+      A = B;
+      fA = fB;
+    } else {
+      fA = fA / 2;
+    }
+    B = C;
+    fB = fC;
+  }
+
+  const newSigma = Math.exp(A / 2);
+
+  // Step 5: Update RD to pre-rating period value
+  const phiStar = Math.sqrt(phiSq + newSigma * newSigma);
+
+  // Step 6: Update rating and RD
+  const newPhi = 1 / Math.sqrt(1 / (phiStar * phiStar) + 1 / v);
+  const newMu = mu + newPhi * newPhi * gPhiJ * (score - eVal);
+
+  // Step 7: Convert back to Glicko scale
+  let newRating = fromGlicko2(newMu);
+  let newRD = rdFromGlicko2(newPhi);
+
+  // Apply rating floor
+  if (newRating < RATING_FLOOR) newRating = RATING_FLOOR;
+
+  // Clamp RD to reasonable bounds
+  if (newRD < 30) newRD = 30;
+  if (newRD > 350) newRD = 350;
+
+  return {
+    rating: Math.round(newRating * 10) / 10,
+    rd: Math.round(newRD * 10) / 10,
+    volatility: Math.round(newSigma * 100000) / 100000
+  };
+}
+
+function isProvisional(gamesPlayed) {
+  return gamesPlayed < PROVISIONAL_THRESHOLD;
+}
+
+module.exports = {
+  updateRating,
+  classifyTimeControl,
+  isProvisional,
+  INITIAL_RATING,
+  INITIAL_RD,
+  INITIAL_VOL,
+  PROVISIONAL_THRESHOLD
+};

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const { upsertUser, formatUser, getRatings } = require('../db');
+const { requireAuth, JWT_SECRET } = require('../middleware/auth');
+
+const router = express.Router();
+
+const WP_URL = process.env.WP_URL || 'https://brennan.games/wp';
+
+// POST /api/auth/login — proxy credentials to WordPress JWT endpoint
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password are required' });
+  }
+
+  try {
+    const wpRes = await fetch(`${WP_URL}/wp-json/jwt-auth/v1/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+
+    if (!wpRes.ok) {
+      const err = await wpRes.json().catch(() => ({}));
+      return res.status(401).json({ error: err.message || 'Invalid credentials' });
+    }
+
+    const wpData = await wpRes.json();
+    const token = wpData.token;
+    const wpUserId = wpData.user_id || wpData.data?.user?.id;
+    const displayName = wpData.user_display_name || wpData.user_nicename || username;
+    const avatarUrl = wpData.user_avatar || null;
+
+    // Upsert user in local database
+    const user = upsertUser(wpUserId, username, displayName, avatarUrl);
+
+    res.json({
+      token,
+      user: formatUser(user)
+    });
+  } catch (e) {
+    console.error('WordPress auth error:', e.message);
+    res.status(502).json({ error: 'Authentication service unavailable' });
+  }
+});
+
+// POST /api/auth/validate — verify token is still valid
+router.post('/validate', requireAuth, (req, res) => {
+  res.json({ valid: true, user: formatUser(req.user) });
+});
+
+// POST /api/auth/logout — server-side no-op (client clears token)
+router.post('/logout', (req, res) => {
+  res.json({ ok: true });
+});
+
+// GET /api/auth/me — full user profile with ratings
+router.get('/me', requireAuth, (req, res) => {
+  const ratings = getRatings(req.user.id);
+  res.json({
+    user: formatUser(req.user),
+    ratings
+  });
+});
+
+module.exports = router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,18 +1,85 @@
 const express = require('express');
-const { upsertUser, formatUser, getRatings } = require('../db');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+const { upsertUser, formatUser, getRatings, getUserByUsername, createLocalUser, getUserWithPassword, getDb } = require('../db');
 const { requireAuth, JWT_SECRET } = require('../middleware/auth');
 
 const router = express.Router();
 
 const WP_URL = process.env.WP_URL || 'https://brennan.games/wp';
+const BCRYPT_ROUNDS = 10;
 
-// POST /api/auth/login — proxy credentials to WordPress JWT endpoint
+/** Sign a JWT for a local user. Matches WordPress JWT format so middleware works. */
+function signToken(user) {
+  return jwt.sign(
+    { data: { user: { id: user.wp_user_id } }, sub: user.id },
+    JWT_SECRET,
+    { expiresIn: '7d' }
+  );
+}
+
+// POST /api/auth/register — create a local account
+router.post('/register', async (req, res) => {
+  const { username, password, displayName } = req.body;
+
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password are required' });
+  }
+
+  if (!/^[a-zA-Z0-9_]{3,30}$/.test(username)) {
+    return res.status(400).json({ error: 'Username must be 3-30 characters (letters, numbers, underscores)' });
+  }
+
+  if (password.length < 6) {
+    return res.status(400).json({ error: 'Password must be at least 6 characters' });
+  }
+
+  const existing = getUserByUsername(username);
+  if (existing) {
+    return res.status(409).json({ error: 'Username already taken' });
+  }
+
+  try {
+    const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
+    const user = createLocalUser(username, displayName || username, passwordHash);
+    const token = signToken(user);
+
+    res.status(201).json({
+      token,
+      user: formatUser(user)
+    });
+  } catch (e) {
+    console.error('Registration error:', e.message);
+    res.status(500).json({ error: 'Registration failed' });
+  }
+});
+
+// POST /api/auth/login — try local auth first, fall back to WordPress
 router.post('/login', async (req, res) => {
   const { username, password } = req.body;
   if (!username || !password) {
     return res.status(400).json({ error: 'Username and password are required' });
   }
 
+  // 1. Try local auth
+  const localUser = getUserWithPassword(username);
+  if (localUser && localUser.password_hash) {
+    try {
+      const match = await bcrypt.compare(password, localUser.password_hash);
+      if (match) {
+        getDb().prepare('UPDATE users SET last_seen_at = ? WHERE id = ?').run(Date.now(), localUser.id);
+        const token = signToken(localUser);
+        return res.json({
+          token,
+          user: formatUser(localUser)
+        });
+      }
+    } catch (e) {
+      // bcrypt error — fall through to WP
+    }
+  }
+
+  // 2. Fall back to WordPress auth
   try {
     const wpRes = await fetch(`${WP_URL}/wp-json/jwt-auth/v1/token`, {
       method: 'POST',
@@ -21,8 +88,7 @@ router.post('/login', async (req, res) => {
     });
 
     if (!wpRes.ok) {
-      const err = await wpRes.json().catch(() => ({}));
-      return res.status(401).json({ error: err.message || 'Invalid credentials' });
+      return res.status(401).json({ error: 'Invalid username or password' });
     }
 
     const wpData = await wpRes.json();
@@ -31,7 +97,6 @@ router.post('/login', async (req, res) => {
     const displayName = wpData.user_display_name || wpData.user_nicename || username;
     const avatarUrl = wpData.user_avatar || null;
 
-    // Upsert user in local database
     const user = upsertUser(wpUserId, username, displayName, avatarUrl);
 
     res.json({
@@ -39,8 +104,7 @@ router.post('/login', async (req, res) => {
       user: formatUser(user)
     });
   } catch (e) {
-    console.error('WordPress auth error:', e.message);
-    res.status(502).json({ error: 'Authentication service unavailable' });
+    return res.status(401).json({ error: 'Invalid username or password' });
   }
 });
 

--- a/routes/friends.js
+++ b/routes/friends.js
@@ -1,0 +1,87 @@
+const express = require('express');
+const { getUserByUsername, getUserById, createFriendship, respondFriendship, getFriendships, getFriendship, removeFriendship } = require('../db');
+const { requireAuth } = require('../middleware/auth');
+
+const router = express.Router();
+
+// GET /api/friends — list friends and pending requests
+router.get('/friends', requireAuth, (req, res) => {
+  const data = getFriendships(req.user.id);
+
+  const formatFriend = (f) => ({
+    friendshipId: f.id,
+    username: f.username,
+    displayName: f.display_name,
+    avatarUrl: f.avatar_url,
+    since: f.updated_at
+  });
+
+  res.json({
+    friends: data.friends.map(formatFriend),
+    pendingIncoming: data.pendingIncoming.map(formatFriend),
+    pendingOutgoing: data.pendingOutgoing.map(formatFriend)
+  });
+});
+
+// POST /api/friends/request — send friend request
+router.post('/friends/request', requireAuth, (req, res) => {
+  const { username } = req.body;
+  if (!username) return res.status(400).json({ error: 'Username is required' });
+
+  const target = getUserByUsername(username);
+  if (!target) return res.status(404).json({ error: 'User not found' });
+  if (target.id === req.user.id) return res.status(400).json({ error: 'Cannot friend yourself' });
+
+  const existing = getFriendship(req.user.id, target.id);
+  if (existing) {
+    if (existing.status === 'accepted') return res.status(409).json({ error: 'Already friends' });
+    if (existing.status === 'pending') return res.status(409).json({ error: 'Request already pending' });
+    if (existing.status === 'blocked') return res.status(403).json({ error: 'Unable to send request' });
+  }
+
+  createFriendship(req.user.id, target.id);
+  res.json({ ok: true });
+});
+
+// POST /api/friends/respond — accept or reject friend request
+router.post('/friends/respond', requireAuth, (req, res) => {
+  const { friendshipId, action } = req.body;
+  if (!friendshipId || !action) {
+    return res.status(400).json({ error: 'friendshipId and action are required' });
+  }
+  if (action !== 'accept' && action !== 'reject') {
+    return res.status(400).json({ error: 'Action must be accept or reject' });
+  }
+
+  const friendship = require('../db').getDb().prepare('SELECT * FROM friendships WHERE id = ?').get(friendshipId);
+  if (!friendship) return res.status(404).json({ error: 'Request not found' });
+  if (friendship.friend_id !== req.user.id) {
+    return res.status(403).json({ error: 'Not your request to respond to' });
+  }
+  if (friendship.status !== 'pending') {
+    return res.status(409).json({ error: 'Request already handled' });
+  }
+
+  if (action === 'accept') {
+    respondFriendship(friendshipId, 'accepted');
+  } else {
+    // Reject by deleting
+    removeFriendship(friendship.user_id, friendship.friend_id);
+  }
+
+  res.json({ ok: true });
+});
+
+// DELETE /api/friends/:userId — remove friend
+router.delete('/friends/:userId', requireAuth, (req, res) => {
+  const friendId = parseInt(req.params.userId);
+  if (!friendId) return res.status(400).json({ error: 'Invalid user ID' });
+
+  const target = getUserById(friendId);
+  if (!target) return res.status(404).json({ error: 'User not found' });
+
+  removeFriendship(req.user.id, friendId);
+  res.sendStatus(204);
+});
+
+module.exports = router;

--- a/routes/game-history.js
+++ b/routes/game-history.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const { listGamesByUser, claimGame, getGame } = require('../db');
+const { requireAuth } = require('../middleware/auth');
+
+const router = express.Router();
+
+// GET /api/my-games — authenticated user's game history
+router.get('/my-games', requireAuth, (req, res) => {
+  const { limit, offset, category, result, opponent } = req.query;
+  const data = listGamesByUser(req.user.id, {
+    limit: parseInt(limit) || 15,
+    offset: parseInt(offset) || 0,
+    category,
+    result,
+    opponent
+  });
+  res.json(data);
+});
+
+// POST /api/games/:id/claim — link an anonymous game to user account
+router.post('/games/:id/claim', requireAuth, (req, res) => {
+  const gameId = parseInt(req.params.id);
+  const { side } = req.body;
+  if (!side || (side !== 'white' && side !== 'black')) {
+    return res.status(400).json({ error: 'Side must be white or black' });
+  }
+
+  const success = claimGame(gameId, side, req.user.id);
+  if (!success) {
+    return res.status(409).json({ error: 'Game not found or already claimed' });
+  }
+  res.json({ ok: true });
+});
+
+// POST /api/games/claim-batch — bulk claim anonymous games on first login
+router.post('/games/claim-batch', requireAuth, (req, res) => {
+  const { gameIds } = req.body;
+  if (!Array.isArray(gameIds)) {
+    return res.status(400).json({ error: 'gameIds array is required' });
+  }
+
+  let claimed = 0;
+  for (const gameId of gameIds) {
+    const game = getGame(gameId);
+    if (!game) continue;
+
+    // Try to match by player name
+    const userName = req.user.display_name || req.user.username;
+    if (game.white.name === userName && !game.white.userId) {
+      if (claimGame(gameId, 'white', req.user.id)) claimed++;
+    }
+    if (game.black.name === userName && !game.black.userId) {
+      if (claimGame(gameId, 'black', req.user.id)) claimed++;
+    }
+  }
+
+  res.json({ claimed, total: gameIds.length });
+});
+
+module.exports = router;

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const { getSettings, updateSettings } = require('../db');
+const { requireAuth } = require('../middleware/auth');
+
+const router = express.Router();
+
+// GET /api/settings — get saved settings
+router.get('/settings', requireAuth, (req, res) => {
+  const settings = getSettings(req.user.id);
+  res.json({ settings });
+});
+
+// PUT /api/settings — save/merge settings
+router.put('/settings', requireAuth, (req, res) => {
+  const { settings } = req.body;
+  if (!settings || typeof settings !== 'object') {
+    return res.status(400).json({ error: 'Settings object is required' });
+  }
+  updateSettings(req.user.id, settings);
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -32,13 +32,18 @@ router.get('/users/:username/games', optionalAuth, (req, res) => {
     return res.status(403).json({ error: 'Game history is private' });
   }
 
-  const { limit, offset, category, result, opponent } = req.query;
+  const { limit, offset, category, result, opponent, gameType, playerType, timeControl, eloMin, eloMax } = req.query;
   const data = listGamesByUser(user.id, {
     limit: parseInt(limit) || 15,
     offset: parseInt(offset) || 0,
     category,
     result,
-    opponent
+    opponent,
+    gameType,
+    playerType,
+    timeControl,
+    eloMin,
+    eloMax
   });
   res.json(data);
 });

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,0 +1,102 @@
+const express = require('express');
+const { getUserByUsername, updateUser, formatUser, getRatings, getRatingHistory, listGamesByUser } = require('../db');
+const { requireAuth, optionalAuth } = require('../middleware/auth');
+
+const router = express.Router();
+
+// GET /api/users/:username — public profile
+router.get('/users/:username', optionalAuth, (req, res) => {
+  const user = getUserByUsername(req.params.username);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  // Check privacy — profile visible to owner or if public
+  const isOwner = req.user && req.user.id === user.id;
+  if (!user.profile_public && !isOwner) {
+    return res.status(404).json({ error: 'User not found' });
+  }
+
+  const ratings = getRatings(user.id);
+  res.json({
+    user: formatUser(user),
+    ratings
+  });
+});
+
+// GET /api/users/:username/games — user's game history
+router.get('/users/:username/games', optionalAuth, (req, res) => {
+  const user = getUserByUsername(req.params.username);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const isOwner = req.user && req.user.id === user.id;
+  if (!user.games_public && !isOwner) {
+    return res.status(403).json({ error: 'Game history is private' });
+  }
+
+  const { limit, offset, category, result, opponent } = req.query;
+  const data = listGamesByUser(user.id, {
+    limit: parseInt(limit) || 15,
+    offset: parseInt(offset) || 0,
+    category,
+    result,
+    opponent
+  });
+  res.json(data);
+});
+
+// GET /api/users/:username/ratings — rating breakdown
+router.get('/users/:username/ratings', optionalAuth, (req, res) => {
+  const user = getUserByUsername(req.params.username);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const isOwner = req.user && req.user.id === user.id;
+  if (!user.profile_public && !isOwner) {
+    return res.status(404).json({ error: 'User not found' });
+  }
+
+  res.json(getRatings(user.id));
+});
+
+// GET /api/users/:username/rating-history — rating changes over time
+router.get('/users/:username/rating-history', optionalAuth, (req, res) => {
+  const user = getUserByUsername(req.params.username);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const isOwner = req.user && req.user.id === user.id;
+  if (!user.profile_public && !isOwner) {
+    return res.status(404).json({ error: 'User not found' });
+  }
+
+  const { category, limit } = req.query;
+  if (!category) {
+    return res.status(400).json({ error: 'Category query parameter is required' });
+  }
+
+  const history = getRatingHistory(user.id, category, parseInt(limit) || 50, 0);
+  res.json(history.map(h => ({
+    gameId: h.game_id,
+    oldRating: h.old_rating,
+    newRating: h.new_rating,
+    oldRd: h.old_rd,
+    newRd: h.new_rd,
+    opponentRating: h.opponent_rating,
+    result: h.result,
+    timestamp: h.timestamp
+  })));
+});
+
+// PATCH /api/users/me — update own profile
+router.patch('/users/me', requireAuth, (req, res) => {
+  const { displayName, bio, avatarUrl, profilePublic, gamesPublic } = req.body;
+  const fields = {};
+  if (displayName !== undefined) fields.display_name = String(displayName).slice(0, 50);
+  if (bio !== undefined) fields.bio = String(bio).slice(0, 500);
+  if (avatarUrl !== undefined) fields.avatar_url = avatarUrl;
+  if (profilePublic !== undefined) fields.profile_public = profilePublic ? 1 : 0;
+  if (gamesPublic !== undefined) fields.games_public = gamesPublic ? 1 : 0;
+
+  updateUser(req.user.id, fields);
+  const updated = getUserByUsername(req.user.username);
+  res.json({ user: formatUser(updated) });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- Local auth system with bcrypt password hashing, JWT tokens, and optional auth middleware
- User profiles with Glicko-2 rating engine (Bullet/Blitz/Rapid/Classical)
- Friends system (send/accept/reject/remove requests, friend list)
- Settings sync and game history endpoints
- Game claiming: links user to games at creation via optionalAuth, batch claim on login
- Server-side game filters: result (win/loss/draw/abandoned/ongoing), playerType, gameType, timeControl, elo range
- Handles both legacy ('1-0'/'0-1') and current ('white'/'black') result formats

## Files Changed (12 files, +1202/-10)
- `db.js` — User accounts schema, query helpers, game filters (+452)
- `rating.js` — Glicko-2 rating engine (+171)
- `middleware/auth.js` — JWT auth + optionalAuth middleware (+45)
- `routes/auth.js` — Register + login endpoints (+130)
- `routes/users.js` — User profile + games endpoint (+107)
- `routes/friends.js` — Friends CRUD (+87)
- `routes/game-history.js` — Game history endpoint (+62)
- `routes/settings.js` — Settings sync (+23)
- `routes/games.js` — optionalAuth on game creation (+12)
- `index.js` — Route registration (+12)
- `package.json` — Added jsonwebtoken dep, version bump

## Test plan
- [x] 13/13 Playwright tests pass
- [x] API endpoint tests pass (register, login, profile, filters)
- [x] Result filters work with both formats
- [x] Ongoing filter returns NULL-result games

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-User-Accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)