### PR TITLE
refactor: namespace API routes under /api/chess

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,19 +31,19 @@ if (process.env.CLIENT_DIR) {
 }
 
 // Health check — includes server version so clients can verify compatibility
-app.get('/api/health', (req, res) => {
+app.get('/api/chess/health', (req, res) => {
   res.json({ status: 'ok', version });
 });
 
 // Game routes
-app.use('/api', gamesRouter);
+app.use('/api/chess', gamesRouter);
 
 // User account routes
-app.use('/api/auth', authRouter);
-app.use('/api', usersRouter);
-app.use('/api', friendsRouter);
-app.use('/api', settingsRouter);
-app.use('/api', gameHistoryRouter);
+app.use('/api/chess/auth', authRouter);
+app.use('/api/chess', usersRouter);
+app.use('/api/chess', friendsRouter);
+app.use('/api/chess', settingsRouter);
+app.use('/api/chess', gameHistoryRouter);
 
 // SPA catch-all: serve index.html for non-API, non-static paths
 // This allows path-based URLs (/replay, /games) to load the app,


### PR DESCRIPTION
## Summary
- Namespaces all chess API routes from `/api/*` to `/api/chess/*`
- Prevents conflicts with other API servers (CMD) sharing the `/api` prefix
- Changes are in `index.js` mount points only — no route file changes needed

## Test plan
- [ ] Verify `GET /api/chess/health` returns 200
- [ ] Verify chess game creation/moves work via `/api/chess/games`
- [ ] Verify auth endpoints work via `/api/chess/auth/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)