### PR TITLE
Video Call Mode

### DIFF
--- a/matchmaking.js
+++ b/matchmaking.js
@@ -5,8 +5,9 @@ const queues = new Map();
 
 const DEFAULT_TC = '5+0';
 
-function joinQueue(ws, sessionId, name, timeControl) {
+function joinQueue(ws, sessionId, name, timeControl, videoEnabled) {
   const tc = timeControl || DEFAULT_TC;
+  const wantsVideo = !!videoEnabled;
 
   // Check if already in a queue
   for (const [, q] of queues) {
@@ -23,10 +24,10 @@ function joinQueue(ws, sessionId, name, timeControl) {
     return;
   }
 
-  const player = { ws, sessionId, name: name || 'Player' };
+  const player = { ws, sessionId, name: name || 'Player', videoEnabled: wantsVideo };
 
-  // Try to find a match
-  const match = findMatch(tc);
+  // Try to find a match (video players only match video players)
+  const match = findMatch(tc, wantsVideo);
   if (match) {
     const { opponent, matchTc } = match;
 
@@ -34,7 +35,7 @@ function joinQueue(ws, sessionId, name, timeControl) {
     if (!opponent.ws || opponent.ws.readyState !== 1) {
       // Opponent disconnected, remove them and retry
       removeFromQueue(opponent.sessionId);
-      return joinQueue(ws, sessionId, name, timeControl);
+      return joinQueue(ws, sessionId, name, timeControl, videoEnabled);
     }
 
     // Match found — create a room with randomly assigned colors
@@ -42,7 +43,8 @@ function joinQueue(ws, sessionId, name, timeControl) {
     const whitePlayer = creatorIsWhite ? opponent : player;
     const blackPlayer = creatorIsWhite ? player : opponent;
 
-    const room = rooms.createRoom(whitePlayer.ws, whitePlayer.sessionId, whitePlayer.name, matchTc);
+    const matchVideoEnabled = wantsVideo && opponent.videoEnabled;
+    const room = rooms.createRoom(whitePlayer.ws, whitePlayer.sessionId, whitePlayer.name, matchTc, matchVideoEnabled);
     rooms.joinRoom(blackPlayer.ws, blackPlayer.sessionId, blackPlayer.name, room.id);
   } else {
     // No match — add to queue
@@ -57,14 +59,25 @@ function joinQueue(ws, sessionId, name, timeControl) {
  * "any" matches with any TC queue. Specific TCs also check the "any" queue.
  * Returns { opponent, matchTc } or null.
  */
-function findMatch(tc) {
+function findMatch(tc, wantsVideo) {
+  // Filter helper: only match players with the same video preference
+  function videoMatches(player) {
+    return !!player.videoEnabled === !!wantsVideo;
+  }
+
+  function takeFirstMatch(queue, queueTc) {
+    const idx = queue.findIndex(videoMatches);
+    if (idx === -1) return null;
+    const opponent = queue.splice(idx, 1)[0];
+    if (queue.length === 0) queues.delete(queueTc);
+    return opponent;
+  }
+
   if (tc === 'any') {
-    // "Any" player: check all queues for any waiting player
+    // "Any" player: check all queues for any waiting player with matching video pref
     for (const [queueTc, queue] of queues) {
-      if (queue.length > 0) {
-        const opponent = queue.shift();
-        if (queue.length === 0) queues.delete(queueTc);
-        // Use the other player's TC, or default if both are "any"
+      const opponent = takeFirstMatch(queue, queueTc);
+      if (opponent) {
         const matchTc = queueTc === 'any' ? DEFAULT_TC : queueTc;
         return { opponent, matchTc };
       }
@@ -74,18 +87,16 @@ function findMatch(tc) {
 
   // Specific TC: check same-TC queue first
   const sameQueue = queues.get(tc);
-  if (sameQueue && sameQueue.length > 0) {
-    const opponent = sameQueue.shift();
-    if (sameQueue.length === 0) queues.delete(tc);
-    return { opponent, matchTc: tc };
+  if (sameQueue) {
+    const opponent = takeFirstMatch(sameQueue, tc);
+    if (opponent) return { opponent, matchTc: tc };
   }
 
   // Then check "any" queue
   const anyQueue = queues.get('any');
-  if (anyQueue && anyQueue.length > 0) {
-    const opponent = anyQueue.shift();
-    if (anyQueue.length === 0) queues.delete('any');
-    return { opponent, matchTc: tc };
+  if (anyQueue) {
+    const opponent = takeFirstMatch(anyQueue, 'any');
+    if (opponent) return { opponent, matchTc: tc };
   }
 
   return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.04.0002",
+  "version": "1.05.0000",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.04.0001",
+  "version": "1.04.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -31,7 +31,7 @@ function parseTimeControl(tc) {
   return { minutes: parseInt(match[1], 10), increment: parseInt(match[2], 10) };
 }
 
-function createRoom(ws, sessionId, name, timeControl) {
+function createRoom(ws, sessionId, name, timeControl, videoEnabled) {
   const roomId = generateRoomCode();
   // "any" defaults to 5+0 for room creation
   const effectiveTc = timeControl === 'any' ? '5+0' : timeControl;
@@ -40,7 +40,7 @@ function createRoom(ws, sessionId, name, timeControl) {
 
   const room = {
     id: roomId,
-    white: { ws, sessionId, name: name || 'White', connected: true },
+    white: { ws, sessionId, name: name || 'White', connected: true, videoReady: false },
     black: null,
     chess: new Chess(),
     timeControl: effectiveTc || 'none',
@@ -50,12 +50,13 @@ function createRoom(ws, sessionId, name, timeControl) {
     dbGameId: null,
     createdAt: Date.now(),
     cleanupTimer: null,
+    videoEnabled: !!videoEnabled,
   };
 
   rooms.set(roomId, room);
   sessionRooms.set(sessionId, roomId);
 
-  send(ws, 'room_created', { roomId, color: 'w' });
+  send(ws, 'room_created', { roomId, color: 'w', videoEnabled: room.videoEnabled });
   return room;
 }
 
@@ -78,7 +79,7 @@ function joinRoom(ws, sessionId, name, roomId) {
     return null;
   }
 
-  room.black = { ws, sessionId, name: name || 'Black', connected: true };
+  room.black = { ws, sessionId, name: name || 'Black', connected: true, videoReady: false };
   room.status = 'playing';
   sessionRooms.set(sessionId, roomId);
 
@@ -102,8 +103,8 @@ function joinRoom(ws, sessionId, name, roomId) {
     timeControl: room.timeControl,
   };
 
-  send(room.white.ws, 'game_start', { ...startPayload, color: 'w', opponentName: room.black.name });
-  send(room.black.ws, 'game_start', { ...startPayload, color: 'b', opponentName: room.white.name });
+  send(room.white.ws, 'game_start', { ...startPayload, color: 'w', opponentName: room.black.name, videoEnabled: room.videoEnabled });
+  send(room.black.ws, 'game_start', { ...startPayload, color: 'b', opponentName: room.white.name, videoEnabled: room.videoEnabled });
 
   return room;
 }
@@ -385,6 +386,7 @@ function attemptReconnect(ws, sessionId, room) {
     clocks: clockPayload,
     opponentName: getPlayerBySide(room, side === 'w' ? 'b' : 'w').name,
     opponentConnected: getPlayerBySide(room, side === 'w' ? 'b' : 'w').connected,
+    videoEnabled: room.videoEnabled,
   });
 
   // Notify opponent
@@ -465,6 +467,40 @@ function getRoomCount() {
   return rooms.size;
 }
 
+// --- WebRTC video signaling ---
+
+function relaySignaling(sessionId, type, payload) {
+  const roomId = sessionRooms.get(sessionId);
+  if (!roomId) return;
+  const room = rooms.get(roomId);
+  if (!room) return;
+  const side = getPlayerSide(room, sessionId);
+  if (!side) return;
+  const opponent = getPlayerBySide(room, side === 'w' ? 'b' : 'w');
+  if (opponent && opponent.ws) {
+    send(opponent.ws, type, payload);
+  }
+}
+
+function handleVideoReady(sessionId) {
+  const roomId = sessionRooms.get(sessionId);
+  if (!roomId) return;
+  const room = rooms.get(roomId);
+  if (!room || !room.videoEnabled) return;
+  const side = getPlayerSide(room, sessionId);
+  if (!side) return;
+  const player = getPlayerBySide(room, side);
+  player.videoReady = true;
+  const opponent = getPlayerBySide(room, side === 'w' ? 'b' : 'w');
+  if (opponent && opponent.videoReady) {
+    // White is always the WebRTC initiator (creates the offer)
+    send(room.white.ws, 'video_start', { initiator: true });
+    send(room.black.ws, 'video_start', { initiator: false });
+  } else if (opponent && opponent.ws) {
+    send(opponent.ws, 'video_peer_ready', {});
+  }
+}
+
 module.exports = {
   createRoom,
   joinRoom,
@@ -475,6 +511,8 @@ module.exports = {
   handleRematchOffer,
   handleRematchResponse,
   handleDisconnect,
+  relaySignaling,
+  handleVideoReady,
   getRoomForSession,
   getRoomCount,
   sessionRooms,

--- a/ws.js
+++ b/ws.js
@@ -44,7 +44,7 @@ function initWebSocket(server) {
       // Route messages
       switch (type) {
         case 'create_room':
-          rooms.createRoom(ws, sessionId, payload?.name, payload?.timeControl);
+          rooms.createRoom(ws, sessionId, payload?.name, payload?.timeControl, payload?.videoEnabled);
           break;
 
         case 'join_room':
@@ -56,7 +56,7 @@ function initWebSocket(server) {
           break;
 
         case 'quick_match':
-          matchmaking.joinQueue(ws, sessionId, payload?.name, payload?.timeControl);
+          matchmaking.joinQueue(ws, sessionId, payload?.name, payload?.timeControl, payload?.videoEnabled);
           break;
 
         case 'cancel_queue':
@@ -93,6 +93,17 @@ function initWebSocket(server) {
 
         case 'rematch_respond':
           rooms.handleRematchResponse(sessionId, !!payload?.accept);
+          break;
+
+        // WebRTC video signaling — relay to opponent
+        case 'rtc_offer':
+        case 'rtc_answer':
+        case 'rtc_ice':
+          rooms.relaySignaling(sessionId, type, payload);
+          break;
+
+        case 'video_ready':
+          rooms.handleVideoReady(sessionId);
           break;
 
         default:


### PR DESCRIPTION
## Summary
Add WebRTC video signaling relay and video-aware matchmaking for live video calls during chess games.

- **rooms.js**: `videoEnabled` flag on rooms, `relaySignaling()` and `handleVideoReady()` functions, video state in `game_start`/`reconnect` payloads
- **ws.js**: 4 new message handlers (`rtc_offer`, `rtc_answer`, `rtc_ice`, `video_ready`)
- **matchmaking.js**: `videoEnabled` filtering — video players only match video players

Server relays WebRTC signaling (SDP offers/answers, ICE candidates) between peers without inspecting content.

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-Video-Call-Mode