### PR TITLE
Active Games & Pending Challenges

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const usersRouter = require('./routes/users');
 const friendsRouter = require('./routes/friends');
 const settingsRouter = require('./routes/settings');
 const gameHistoryRouter = require('./routes/game-history');
+const roomsRouter = require('./routes/rooms');
 const { initWebSocket } = require('./ws');
 const { version } = require('./package.json');
 
@@ -44,6 +45,7 @@ app.use('/api', usersRouter);
 app.use('/api', friendsRouter);
 app.use('/api', settingsRouter);
 app.use('/api', gameHistoryRouter);
+app.use('/api', roomsRouter);
 
 // SPA catch-all: serve index.html for non-API, non-static paths
 // This allows path-based URLs (/replay, /games) to load the app,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.04.0000",
+  "version": "1.04.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -10,6 +10,7 @@ const sessionRooms = new Map();
 const ROOM_CODE_LENGTH = 6;
 const ROOM_TTL_AFTER_END = 5 * 60 * 1000;     // 5 min
 const DISCONNECT_GRACE_PERIOD = 60 * 1000;      // 60s
+const WAITING_ROOM_TTL = 30 * 60 * 1000;        // 30 min grace for pending rooms
 
 function generateRoomCode() {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no I/O/0/1 to avoid confusion
@@ -74,8 +75,15 @@ function joinRoom(ws, sessionId, name, roomId) {
     return null;
   }
   if (room.white.sessionId === sessionId) {
-    send(ws, 'error', { message: 'You are already in this room' });
-    return null;
+    // Creator reconnecting to their waiting room
+    room.white.ws = ws;
+    room.white.connected = true;
+    if (room.waitingCleanupTimer) {
+      clearTimeout(room.waitingCleanupTimer);
+      room.waitingCleanupTimer = null;
+    }
+    send(ws, 'room_created', { roomId: room.id, color: 'w' });
+    return room;
   }
 
   room.black = { ws, sessionId, name: name || 'Black', connected: true };
@@ -331,8 +339,15 @@ function handleDisconnect(sessionId) {
   player.disconnectedAt = Date.now();
 
   if (room.status === 'waiting') {
-    // Creator disconnected before anyone joined — remove room
-    cleanupRoom(roomId);
+    // Creator disconnected — keep room alive with a grace period
+    if (!room.waitingCleanupTimer) {
+      room.waitingCleanupTimer = setTimeout(() => {
+        const r = rooms.get(roomId);
+        if (r && r.status === 'waiting' && !r.white.connected) {
+          cleanupRoom(roomId);
+        }
+      }, WAITING_ROOM_TTL);
+    }
     return;
   }
 
@@ -434,6 +449,7 @@ function cleanupRoom(roomId) {
   if (room.black) sessionRooms.delete(room.black.sessionId);
   clearTimeout(room.cleanupTimer);
   clearTimeout(room.disconnectTimer);
+  clearTimeout(room.waitingCleanupTimer);
   rooms.delete(roomId);
 }
 
@@ -465,6 +481,47 @@ function getRoomCount() {
   return rooms.size;
 }
 
+/**
+ * List all rooms where the session is a participant (waiting or playing).
+ * Returns serializable room summaries (no ws references).
+ */
+function listRoomsForSession(sessionId) {
+  const result = [];
+  for (const room of rooms.values()) {
+    const side = getPlayerSide(room, sessionId);
+    if (!side) continue;
+    if (room.status !== 'waiting' && room.status !== 'playing') continue;
+    result.push({
+      roomId: room.id,
+      status: room.status,
+      timeControl: room.timeControl,
+      createdAt: room.createdAt,
+      color: side,
+      moveCount: room.moves.length,
+      white: { name: room.white.name },
+      black: room.black ? { name: room.black.name } : null,
+      dbGameId: room.dbGameId,
+    });
+  }
+  return result;
+}
+
+/**
+ * Cancel a waiting room owned by the session.
+ * Returns true if cancelled, false if not found or not allowed.
+ */
+function cancelRoom(sessionId) {
+  const roomId = sessionRooms.get(sessionId);
+  if (!roomId) return false;
+
+  const room = rooms.get(roomId);
+  if (!room || room.status !== 'waiting') return false;
+  if (room.white.sessionId !== sessionId) return false;
+
+  cleanupRoom(roomId);
+  return true;
+}
+
 module.exports = {
   createRoom,
   joinRoom,
@@ -477,5 +534,7 @@ module.exports = {
   handleDisconnect,
   getRoomForSession,
   getRoomCount,
+  listRoomsForSession,
+  cancelRoom,
   sessionRooms,
 };

--- a/routes/rooms.js
+++ b/routes/rooms.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router();
+const { listRoomsForSession } = require('../rooms');
+
+// GET /api/rooms/active — List active/pending rooms for a session
+router.get('/rooms/active', (req, res) => {
+  const sessionId = req.query.sessionId;
+  if (!sessionId) {
+    return res.status(400).json({ error: 'sessionId query parameter required' });
+  }
+  const activeRooms = listRoomsForSession(sessionId);
+  res.json({ rooms: activeRooms });
+});
+
+module.exports = router;

--- a/ws.js
+++ b/ws.js
@@ -5,6 +5,9 @@ const matchmaking = require('./matchmaking');
 // Map WebSocket → sessionId for disconnect handling
 const connections = new Map();
 
+// Track connection count per sessionId for multi-tab safety
+const sessionConnectionCount = new Map();
+
 function initWebSocket(server) {
   const wss = new WebSocketServer({ server, path: '/ws' });
 
@@ -31,13 +34,26 @@ function initWebSocket(server) {
         sessionId = payload.sessionId;
         connections.set(ws, sessionId);
 
+        // Track connection count for this session
+        const count = sessionConnectionCount.get(sessionId) || 0;
+        sessionConnectionCount.set(sessionId, count + 1);
+
         // Check for existing room to reconnect
         const existingRoom = rooms.getRoomForSession(sessionId);
         if (existingRoom && existingRoom.status === 'playing') {
           rooms.joinRoom(ws, sessionId, null, existingRoom.id);
+        } else if (existingRoom && existingRoom.status === 'waiting') {
+          // Reconnect to waiting room (updates ws reference)
+          rooms.joinRoom(ws, sessionId, null, existingRoom.id);
         }
 
         send(ws, 'auth_ok', {});
+
+        // Auto-send rooms list on connect
+        const userRooms = rooms.listRoomsForSession(sessionId);
+        if (userRooms.length > 0) {
+          send(ws, 'rooms_list', { rooms: userRooms });
+        }
         return;
       }
 
@@ -95,6 +111,18 @@ function initWebSocket(server) {
           rooms.handleRematchResponse(sessionId, !!payload?.accept);
           break;
 
+        case 'list_rooms':
+          send(ws, 'rooms_list', { rooms: rooms.listRoomsForSession(sessionId) });
+          break;
+
+        case 'cancel_room':
+          if (rooms.cancelRoom(sessionId)) {
+            send(ws, 'room_cancelled', {});
+          } else {
+            send(ws, 'error', { message: 'No waiting room to cancel' });
+          }
+          break;
+
         default:
           send(ws, 'error', { message: `Unknown message type: ${type}` });
       }
@@ -102,9 +130,18 @@ function initWebSocket(server) {
 
     ws.on('close', () => {
       if (sessionId) {
-        rooms.handleDisconnect(sessionId);
-        matchmaking.handleDisconnect(sessionId);
         connections.delete(ws);
+
+        // Decrement connection count — only disconnect room when no connections remain
+        const count = (sessionConnectionCount.get(sessionId) || 1) - 1;
+        if (count <= 0) {
+          sessionConnectionCount.delete(sessionId);
+          rooms.handleDisconnect(sessionId);
+        } else {
+          sessionConnectionCount.set(sessionId, count);
+        }
+
+        matchmaking.handleDisconnect(sessionId);
       }
     });
 


### PR DESCRIPTION
## Summary
- Add 30-minute grace period for waiting rooms (instead of immediate cleanup on disconnect)
- Add `listRoomsForSession()` and `cancelRoom()` to rooms.js
- Add `GET /api/chess/rooms/active` REST endpoint for game browser
- Add `list_rooms` and `cancel_room` WebSocket message handlers
- Track multi-tab connections per session (only disconnect when all tabs close)
- Auto-send rooms list on WebSocket auth

## Test plan
- [ ] Create a room, verify it persists after page refresh (30-min grace period)
- [ ] Verify `GET /api/chess/rooms/active?sessionId=xxx` returns pending rooms
- [ ] Verify `cancel_room` WS message removes waiting room
- [ ] Verify multi-tab safety (opening second tab doesn't kill room)