### PR TITLE
Chess960 Multiplayer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ REST API server for persistent chess game storage. Stores games and moves in a S
 
 ## Version
 
-**Current:** `1.07.0000`
+**Current:** `1.08.0000`
 
 The `/api/health` endpoint returns the server version. The client checks this on startup to verify compatibility.
 

--- a/matchmaking.js
+++ b/matchmaking.js
@@ -5,7 +5,7 @@ const queues = new Map();
 
 const DEFAULT_TC = '5+0';
 
-function joinQueue(ws, sessionId, name, timeControl, videoEnabled) {
+function joinQueue(ws, sessionId, name, timeControl, videoEnabled, chess960) {
   const tc = timeControl || DEFAULT_TC;
   const wantsVideo = !!videoEnabled;
 
@@ -24,10 +24,11 @@ function joinQueue(ws, sessionId, name, timeControl, videoEnabled) {
     return;
   }
 
-  const player = { ws, sessionId, name: name || 'Player', videoEnabled: wantsVideo };
+  const wantsChess960 = !!chess960;
+  const player = { ws, sessionId, name: name || 'Player', videoEnabled: wantsVideo, chess960: wantsChess960 };
 
-  // Try to find a match (video players only match video players)
-  const match = findMatch(tc, wantsVideo);
+  // Try to find a match (video and chess960 preferences must match)
+  const match = findMatch(tc, wantsVideo, wantsChess960);
   if (match) {
     const { opponent, matchTc } = match;
 
@@ -35,7 +36,7 @@ function joinQueue(ws, sessionId, name, timeControl, videoEnabled) {
     if (!opponent.ws || opponent.ws.readyState !== 1) {
       // Opponent disconnected, remove them and retry
       removeFromQueue(opponent.sessionId);
-      return joinQueue(ws, sessionId, name, timeControl, videoEnabled);
+      return joinQueue(ws, sessionId, name, timeControl, videoEnabled, chess960);
     }
 
     // Match found — create a room with randomly assigned colors
@@ -44,7 +45,8 @@ function joinQueue(ws, sessionId, name, timeControl, videoEnabled) {
     const blackPlayer = creatorIsWhite ? player : opponent;
 
     const matchVideoEnabled = wantsVideo && opponent.videoEnabled;
-    const room = rooms.createRoom(whitePlayer.ws, whitePlayer.sessionId, whitePlayer.name, matchTc, matchVideoEnabled);
+    const matchChess960 = wantsChess960 && opponent.chess960;
+    const room = rooms.createRoom(whitePlayer.ws, whitePlayer.sessionId, whitePlayer.name, matchTc, matchVideoEnabled, matchChess960);
     rooms.joinRoom(blackPlayer.ws, blackPlayer.sessionId, blackPlayer.name, room.id);
   } else {
     // No match — add to queue
@@ -59,14 +61,14 @@ function joinQueue(ws, sessionId, name, timeControl, videoEnabled) {
  * "any" matches with any TC queue. Specific TCs also check the "any" queue.
  * Returns { opponent, matchTc } or null.
  */
-function findMatch(tc, wantsVideo) {
-  // Filter helper: only match players with the same video preference
-  function videoMatches(player) {
-    return !!player.videoEnabled === !!wantsVideo;
+function findMatch(tc, wantsVideo, wantsChess960) {
+  // Filter helper: only match players with the same video and chess960 preferences
+  function preferencesMatch(player) {
+    return !!player.videoEnabled === !!wantsVideo && !!player.chess960 === !!wantsChess960;
   }
 
   function takeFirstMatch(queue, queueTc) {
-    const idx = queue.findIndex(videoMatches);
+    const idx = queue.findIndex(preferencesMatch);
     if (idx === -1) return null;
     const opponent = queue.splice(idx, 1)[0];
     if (queue.length === 0) queues.delete(queueTc);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.07.0000",
+  "version": "1.08.0000",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.06.0000",
+  "version": "1.06.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -24,6 +24,31 @@ function generateRoomCode() {
   return code;
 }
 
+function generateChess960FEN() {
+  const pieces = ['r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'];
+  let backRank;
+  let valid = false;
+  while (!valid) {
+    // Fisher-Yates shuffle
+    backRank = pieces.slice();
+    for (let i = backRank.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [backRank[i], backRank[j]] = [backRank[j], backRank[i]];
+    }
+    const kingPos = backRank.indexOf('k');
+    const rook1Pos = backRank.indexOf('r');
+    const rook2Pos = backRank.lastIndexOf('r');
+    const bishop1Pos = backRank.indexOf('b');
+    const bishop2Pos = backRank.lastIndexOf('b');
+    const bishopsOnOppositeColors = (bishop1Pos % 2) !== (bishop2Pos % 2);
+    const kingBetweenRooks = rook1Pos < kingPos && kingPos < rook2Pos;
+    valid = bishopsOnOppositeColors && kingBetweenRooks;
+  }
+  const rank8 = backRank.join('');
+  const rank1 = backRank.join('').toUpperCase();
+  return `${rank8}/pppppppp/8/8/8/8/PPPPPPPP/${rank1} w - - 0 1`;
+}
+
 function parseTimeControl(tc) {
   if (!tc || tc === 'none') return null;
   // Format: "5+0", "10+5", "3+2", etc.
@@ -32,18 +57,21 @@ function parseTimeControl(tc) {
   return { minutes: parseInt(match[1], 10), increment: parseInt(match[2], 10) };
 }
 
-function createRoom(ws, sessionId, name, timeControl, videoEnabled) {
+function createRoom(ws, sessionId, name, timeControl, videoEnabled, chess960) {
   const roomId = generateRoomCode();
   // "any" defaults to 5+0 for room creation
   const effectiveTc = timeControl === 'any' ? '5+0' : timeControl;
   const tc = parseTimeControl(effectiveTc);
   const timeMs = tc ? tc.minutes * 60 * 1000 : 0;
 
+  const is960 = !!chess960;
+  const startFen = is960 ? generateChess960FEN() : undefined;
+
   const room = {
     id: roomId,
     white: { ws, sessionId, name: name || 'White', connected: true, videoReady: false },
     black: null,
-    chess: new Chess(),
+    chess: startFen ? new Chess(startFen) : new Chess(),
     timeControl: effectiveTc || 'none',
     clocks: tc ? { w: timeMs, b: timeMs, increment: tc.increment * 1000, lastMoveAt: null } : null,
     moves: [],
@@ -52,6 +80,7 @@ function createRoom(ws, sessionId, name, timeControl, videoEnabled) {
     createdAt: Date.now(),
     cleanupTimer: null,
     videoEnabled: !!videoEnabled,
+    chess960: is960,
   };
 
   rooms.set(roomId, room);
@@ -109,6 +138,7 @@ function joinRoom(ws, sessionId, name, roomId) {
     roomId: room.id,
     fen: room.chess.fen(),
     timeControl: room.timeControl,
+    chess960: room.chess960,
   };
 
   send(room.white.ws, 'game_start', { ...startPayload, color: 'w', opponentName: room.black.name, videoEnabled: room.videoEnabled });
@@ -293,7 +323,8 @@ function handleRematchResponse(sessionId, accept) {
 
   room.white = { ws: oldBlack.ws, sessionId: oldBlack.sessionId, name: oldBlack.name, connected: oldBlack.connected };
   room.black = { ws: oldWhite.ws, sessionId: oldWhite.sessionId, name: oldWhite.name, connected: oldWhite.connected };
-  room.chess = new Chess();
+  const rematchFen = room.chess960 ? generateChess960FEN() : undefined;
+  room.chess = rematchFen ? new Chess(rematchFen) : new Chess();
   room.moves = [];
   room.status = 'playing';
   room.rematchOfferedBy = null;
@@ -318,6 +349,7 @@ function handleRematchResponse(sessionId, accept) {
     roomId: room.id,
     fen: room.chess.fen(),
     timeControl: room.timeControl,
+    chess960: room.chess960,
   };
 
   send(room.white.ws, 'rematch_start', { ...startPayload, color: 'w', opponentName: room.black.name });
@@ -402,6 +434,7 @@ function attemptReconnect(ws, sessionId, room) {
     opponentName: getPlayerBySide(room, side === 'w' ? 'b' : 'w').name,
     opponentConnected: getPlayerBySide(room, side === 'w' ? 'b' : 'w').connected,
     videoEnabled: room.videoEnabled,
+    chess960: room.chess960,
   });
 
   // Notify opponent

--- a/ws.js
+++ b/ws.js
@@ -60,7 +60,7 @@ function initWebSocket(server) {
       // Route messages
       switch (type) {
         case 'create_room':
-          rooms.createRoom(ws, sessionId, payload?.name, payload?.timeControl, payload?.videoEnabled);
+          rooms.createRoom(ws, sessionId, payload?.name, payload?.timeControl, payload?.videoEnabled, payload?.chess960);
           break;
 
         case 'join_room':
@@ -72,7 +72,7 @@ function initWebSocket(server) {
           break;
 
         case 'quick_match':
-          matchmaking.joinQueue(ws, sessionId, payload?.name, payload?.timeControl, payload?.videoEnabled);
+          matchmaking.joinQueue(ws, sessionId, payload?.name, payload?.timeControl, payload?.videoEnabled, payload?.chess960);
           break;
 
         case 'cancel_queue':


### PR DESCRIPTION
## Summary
- Pass chess960 flag through WebSocket routing (ws.js)
- Generate Chess960 FEN server-side (rooms.js) for consistent positions
- Include chess960 in game_start, rematch_start, and reconnect payloads
- Match chess960 preferences in matchmaking queue

## Files Changed
- `ws.js` — Route chess960 to rooms/matchmaking
- `rooms.js` — generateChess960FEN(), chess960 on room object, in all payloads
- `matchmaking.js` — chess960 preference matching in queue

## Test Plan
- [ ] WebSocket create_room with chess960=true generates non-standard FEN
- [ ] Both players receive identical FEN in game_start
- [ ] Matchmaking matches chess960 preferences correctly

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-Chess960-Multiplayer