### PR TITLE
Add /api/chess/ice-servers endpoint for WebRTC TURN configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const friendsRouter = require('./routes/friends');
 const settingsRouter = require('./routes/settings');
 const gameHistoryRouter = require('./routes/game-history');
 const roomsRouter = require('./routes/rooms');
+const iceServersRouter = require('./routes/ice-servers');
 const { initWebSocket } = require('./ws');
 const { version } = require('./package.json');
 
@@ -46,6 +47,7 @@ app.use('/api/chess', friendsRouter);
 app.use('/api/chess', settingsRouter);
 app.use('/api/chess', gameHistoryRouter);
 app.use('/api/chess', roomsRouter);
+app.use('/api/chess', iceServersRouter);
 
 // SPA catch-all: serve index.html for non-API, non-static paths
 // This allows path-based URLs (/replay, /games) to load the app,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.08.0000",
+  "version": "1.08.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/ice-servers.js
+++ b/routes/ice-servers.js
@@ -1,0 +1,49 @@
+/**
+ * ICE server configuration endpoint.
+ *
+ * Returns STUN servers always. Returns TURN credentials as well if
+ * TURN_SECRET and TURN_URL are configured as environment variables.
+ *
+ * TURN credentials use the coturn REST API format (HMAC-SHA1 with a
+ * shared secret), giving 24-hour time-limited tokens.
+ */
+
+const express = require('express');
+const crypto = require('crypto');
+const router = express.Router();
+
+const STUN_SERVERS = [
+  { urls: 'stun:stun.l.google.com:19302' },
+  { urls: 'stun:stun1.l.google.com:19302' },
+];
+
+// GET /api/chess/ice-servers — returns ICE server config for WebRTC
+router.get('/ice-servers', (req, res) => {
+  const turnSecret = process.env.TURN_SECRET;
+  const turnUrl = process.env.TURN_URL;
+
+  if (!turnSecret || !turnUrl) {
+    return res.json(STUN_SERVERS);
+  }
+
+  // Generate time-limited TURN credentials (expire in 24h)
+  const expiry = Math.floor(Date.now() / 1000) + 86400;
+  const username = String(expiry);
+  const credential = crypto
+    .createHmac('sha1', turnSecret)
+    .update(username)
+    .digest('base64');
+
+  const servers = [
+    ...STUN_SERVERS,
+    {
+      urls: [`turn:${turnUrl}`, `turns:${turnUrl}`],
+      username,
+      credential,
+    },
+  ];
+
+  res.json(servers);
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary

- New `GET /api/chess/ice-servers` endpoint returns STUN servers by default
- When `TURN_SECRET` and `TURN_URL` env vars are set, generates time-limited HMAC-SHA1 TURN credentials (coturn REST API format, 24h expiry)
- Required by chess-client PR #87 (WebRTC ICE fix)

## Test plan

- [ ] `curl /api/chess/ice-servers` returns STUN server array
- [ ] With `TURN_SECRET`+`TURN_URL` env vars set, response includes TURN entry with valid username/credential
- [ ] Server starts without errors