### PR TITLE
Fix default player name to 'Opponent' in multiplayer

### DIFF
--- a/matchmaking.js
+++ b/matchmaking.js
@@ -25,7 +25,7 @@ function joinQueue(ws, sessionId, name, timeControl, videoEnabled, chess960) {
   }
 
   const wantsChess960 = !!chess960;
-  const player = { ws, sessionId, name: name || 'Player', videoEnabled: wantsVideo, chess960: wantsChess960 };
+  const player = { ws, sessionId, name: name || 'Opponent', videoEnabled: wantsVideo, chess960: wantsChess960 };
 
   // Try to find a match (video and chess960 preferences must match)
   const match = findMatch(tc, wantsVideo, wantsChess960);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.10.0000",
+  "version": "1.10.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -69,7 +69,7 @@ function createRoom(ws, sessionId, name, timeControl, videoEnabled, chess960) {
 
   const room = {
     id: roomId,
-    white: { ws, sessionId, name: name || 'White', connected: true, videoReady: false },
+    white: { ws, sessionId, name: name || 'Opponent', connected: true, videoReady: false },
     black: null,
     chess: startFen ? new Chess(startFen) : new Chess(),
     timeControl: effectiveTc || 'none',
@@ -117,7 +117,7 @@ function joinRoom(ws, sessionId, name, roomId) {
   }
 
   // Randomly assign colors — 50/50 chance creator gets white or black
-  const joiner = { ws, sessionId, name: name || 'Joiner', connected: true, videoReady: false };
+  const joiner = { ws, sessionId, name: name || 'Opponent', connected: true, videoReady: false };
   const creator = room.white;
   if (Math.random() < 0.5) {
     room.white = joiner;


### PR DESCRIPTION
## Summary

Changed the fallback name used when a player joins an online game without entering a name. Previously showed "White", "Joiner", or "Player" — now shows "Opponent".

## Changes

- \`rooms.js\` — \`name || 'Opponent'\` for room creator (was \`'White'\`) and joiner (was \`'Joiner'\`)
- \`matchmaking.js\` — \`name || 'Opponent'\` for quick match queue (was \`'Player'\`)

Only affects online multiplayer. Local games use separate client-side naming and are not affected.

## Test plan

- [ ] Join an online game without entering a name — the other player should see "Opponent"
- [ ] Host an online game without entering a name — the other player should see "Opponent"
- [ ] Quick match with no name — opponent should see "Opponent"