### PR TITLE
Multiplayer Reconnection & Connection Status Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ REST API server for persistent chess game storage. Stores games and moves in a S
 
 ## Version
 
-**Current:** `1.12.0000`
+**Current:** `1.16.0000`
 
 The `/api/health` endpoint returns the server version. The client checks this on startup to verify compatibility.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.11.0000",
+  "version": "1.11.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.15.0001",
+  "version": "1.16.0000",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/ws.js
+++ b/ws.js
@@ -40,14 +40,13 @@ function initWebSocket(server) {
 
         // Check for existing room to reconnect
         const existingRoom = rooms.getRoomForSession(sessionId);
-        if (existingRoom && existingRoom.status === 'playing') {
-          rooms.joinRoom(ws, sessionId, null, existingRoom.id);
-        } else if (existingRoom && existingRoom.status === 'waiting') {
-          // Reconnect to waiting room (updates ws reference)
-          rooms.joinRoom(ws, sessionId, null, existingRoom.id);
+        let reconnected = false;
+        if (existingRoom && (existingRoom.status === 'playing' || existingRoom.status === 'waiting')) {
+          const joinResult = rooms.joinRoom(ws, sessionId, null, existingRoom.id);
+          reconnected = !!joinResult;
         }
 
-        send(ws, 'auth_ok', {});
+        send(ws, 'auth_ok', { inRoom: reconnected, roomId: reconnected ? existingRoom.id : null });
 
         // Auto-send rooms list on connect
         const userRooms = rooms.listRoomsForSession(sessionId);
@@ -165,6 +164,11 @@ function initWebSocket(server) {
 
         case 'review_exit':
           rooms.handleReviewExit(sessionId);
+          break;
+
+        // Application-level heartbeat
+        case 'ping':
+          send(ws, 'pong', { ts: payload?.ts });
           break;
 
         default:


### PR DESCRIPTION
## Summary

- `auth_ok` now includes `{ inRoom, roomId }` so clients know if room reconnection succeeded
- Added application-level `ping`/`pong` heartbeat handler
- Fixes the "Not in a room" error that caused games to become stuck

## Changes
- `ws.js`: Room-aware auth_ok payload, ping/pong handler
- `package.json`: Version bump to 1.15.0001

## Test plan
- [x] 9/9 WebSocket API tests pass (auth_ok inRoom, heartbeat, disconnect/reconnect, moves after reconnect)
- [x] Browser UI verified with Playwright screenshots

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-Multiplayer-Reconnection