### PR TITLE
Recent Game Diagnostics Endpoint

### DIFF
--- a/db.js
+++ b/db.js
@@ -720,6 +720,15 @@ function getDiagnosticsBySession(sessionId, { category, limit, offset } = {}) {
   return db.prepare(sql).all(...params).map(formatDiagnosticEvent);
 }
 
+function getDiagnosticsRecent({ category, limit, offset } = {}) {
+  const row = db.prepare(
+    'SELECT game_id FROM diagnostic_events WHERE game_id IS NOT NULL ORDER BY game_id DESC LIMIT 1'
+  ).get();
+  if (!row) return { gameId: null, events: [], count: 0 };
+  const events = getDiagnosticsByGame(row.game_id, { category, limit, offset });
+  return { gameId: row.game_id, events, count: events.length };
+}
+
 function cleanupOldDiagnostics(maxAgeDays = 30) {
   const cutoff = Date.now() - (maxAgeDays * 24 * 60 * 60 * 1000);
   const info = db.prepare('DELETE FROM diagnostic_events WHERE created_at < ?').run(cutoff);
@@ -786,5 +795,6 @@ module.exports = {
   getDiagnosticsByGame,
   getDiagnosticsByRoom,
   getDiagnosticsBySession,
+  getDiagnosticsRecent,
   cleanupOldDiagnostics,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.15.0000"
+  "version": "1.15.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics.js
+++ b/routes/diagnostics.js
@@ -5,6 +5,7 @@ const {
   getDiagnosticsByGame,
   getDiagnosticsByRoom,
   getDiagnosticsBySession,
+  getDiagnosticsRecent,
 } = require('../db');
 
 const MAX_BATCH_SIZE = 100;
@@ -91,6 +92,23 @@ router.get('/diagnostics/session/:id', (req, res) => {
     res.json({ sessionId, events, count: events.length });
   } catch (e) {
     console.error('GET /diagnostics/session/:id error:', e.message);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// GET /api/chess/diagnostics/recent — diagnostics for the most recent game
+router.get('/diagnostics/recent', (req, res) => {
+  try {
+    const { category, limit = 500, offset = 0 } = req.query;
+    const result = getDiagnosticsRecent({
+      category: category || null,
+      limit: Math.min(parseInt(limit, 10) || 500, 1000),
+      offset: parseInt(offset, 10) || 0,
+    });
+    if (result.gameId === null) return res.status(404).json({ error: 'No game diagnostics found' });
+    res.json(result);
+  } catch (e) {
+    console.error('GET /diagnostics/recent error:', e.message);
     res.status(500).json({ error: e.message });
   }
 });


### PR DESCRIPTION
Adds `GET /api/chess/diagnostics/recent` — returns diagnostics for the most recently played game (highest `game_id`) without needing to know the game ID upfront.

## Changes
- `routes/diagnostics.js` — new route handler
- `db.js` — new `getDiagnosticsRecent()` function
- `package.json` — version `1.15.0000 → 1.16.0001`

## Response
```json
{ "gameId": 42, "events": [...], "count": 18 }
```
Optional query params: `?category=webrtc&limit=10&offset=0`
Returns 404 if no game diagnostics exist.

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-Recent-Game-Diagnostics-Endpoint