### PR TITLE
Fix TURN credentials and add WebRTC diagnostics summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.17.0001",
+  "version": "1.17.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -6,6 +6,7 @@ const CATEGORY_COLORS = {
   move:      '#22c55e',
   connection:'#f59e0b',
   sync:      '#8b5cf6',
+  webrtc:    '#06b6d4',
   unknown:   '#6b7280',
 };
 
@@ -57,6 +58,81 @@ function categoryLegend(events) {
   }).join('');
 }
 
+/**
+ * Compute WebRTC summary stats from a session's events.
+ * Returns null if no webrtc events exist for the session.
+ */
+function computeWebRtcSummary(events) {
+  const webrtcEvents = events.filter(e => e.category === 'webrtc');
+  if (webrtcEvents.length === 0) return null;
+
+  const summary = {
+    hasTurn: false,
+    serverCount: 0,
+    candidates: { host: 0, srflx: 0, relay: 0, prflx: 0, unknown: 0 },
+    iceState: null,
+    connectionState: null,
+    videoReceived: false,
+    audioReceived: false,
+  };
+
+  for (const e of webrtcEvents) {
+    const d = e.data || {};
+    if (e.eventType === 'ice_servers_config') {
+      summary.hasTurn = !!d.hasTurn;
+      summary.serverCount = d.count || 0;
+    } else if (e.eventType === 'ice_candidate_local') {
+      const t = d.type || 'unknown';
+      if (t in summary.candidates) summary.candidates[t]++;
+      else summary.candidates.unknown++;
+    } else if (e.eventType === 'ice_state_change') {
+      summary.iceState = d.state || d.iceState || null;
+    } else if (e.eventType === 'connection_state_change') {
+      summary.connectionState = d.state || d.connectionState || null;
+    } else if (e.eventType === 'remote_track_received') {
+      if (d.kind === 'video') summary.videoReceived = true;
+      if (d.kind === 'audio') summary.audioReceived = true;
+    }
+  }
+
+  return summary;
+}
+
+function renderWebRtcSummary(summary) {
+  if (!summary) return '';
+
+  const relayCount = summary.candidates.relay;
+  const turnOk = relayCount > 0;
+  const iceOk = summary.iceState === 'connected' || summary.iceState === 'completed';
+  const connOk = summary.connectionState === 'connected';
+
+  const turnLabel = summary.hasTurn
+    ? (turnOk
+        ? `<span class="wrtc-ok">TURN ✓ (${relayCount} relay)</span>`
+        : `<span class="wrtc-warn">TURN ⚠ (0 relay)</span>`)
+    : `<span class="wrtc-off">TURN off</span>`;
+
+  const iceLabel = summary.iceState
+    ? (iceOk
+        ? `<span class="wrtc-ok">ICE: ${escapeHtml(summary.iceState)}</span>`
+        : `<span class="wrtc-fail">ICE: ${escapeHtml(summary.iceState)}</span>`)
+    : '';
+
+  const connLabel = summary.connectionState
+    ? (connOk
+        ? `<span class="wrtc-ok">conn: ${escapeHtml(summary.connectionState)}</span>`
+        : `<span class="wrtc-fail">conn: ${escapeHtml(summary.connectionState)}</span>`)
+    : '';
+
+  const candidateLabel = `<span class="wrtc-dim">host:${summary.candidates.host} srflx:${summary.candidates.srflx} relay:${relayCount}</span>`;
+
+  const videoLabel = summary.videoReceived
+    ? `<span class="wrtc-ok">video ✓</span>`
+    : `<span class="wrtc-fail">video ✗</span>`;
+
+  return `<div class="webrtc-summary">${turnLabel} · ${iceLabel}${connLabel ? ' · ' + connLabel : ''} · ${candidateLabel} · ${videoLabel}</div>`;
+}
+
 function renderEventRow(e, baseTs) {
   const color = categoryColor(e.category);
   const dataStr = escapeHtml(JSON.stringify(e.data || {}, null, 2));
@@ -85,6 +161,8 @@ function renderSessionSection(sessionId, events) {
     .map(([c, n]) => `<span class="badge sm" style="background:${categoryColor(c)}">${n} ${escapeHtml(c)}</span>`)
     .join(' ');
 
+  const webRtcSummary = renderWebRtcSummary(computeWebRtcSummary(events));
+
   return `<details class="session-section" open>
   <summary class="session-header">
     <div class="session-device">
@@ -98,6 +176,7 @@ function renderSessionSection(sessionId, events) {
       <span class="session-id" title="${escapeHtml(sessionId)}">${escapeHtml(shortId)}…</span>
     </div>
   </summary>
+  ${webRtcSummary}
   <div class="session-events">
     ${events.map(e => renderEventRow(e, baseTs)).join('\n')}
   </div>
@@ -163,6 +242,14 @@ function renderDiagnosticsHTML(result, context) {
   .device-screen { color: #475569; font-size: 11px; }
   .session-right { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-left: auto; }
   .session-id { color: #475569; font-size: 11px; }
+
+  /* WebRTC summary bar */
+  .webrtc-summary { padding: 6px 16px; background: #0f172a; border-bottom: 1px solid #1e293b; font-size: 11px; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+  .wrtc-ok   { color: #4ade80; font-weight: 600; }
+  .wrtc-warn { color: #fb923c; font-weight: 600; }
+  .wrtc-fail { color: #f87171; font-weight: 600; }
+  .wrtc-off  { color: #475569; }
+  .wrtc-dim  { color: #64748b; }
 
   /* Events */
   .session-events { padding: 0 16px 12px; display: flex; flex-direction: column; gap: 4px; margin-top: 8px; }

--- a/routes/ice-servers.js
+++ b/routes/ice-servers.js
@@ -1,11 +1,20 @@
 /**
  * ICE server configuration endpoint.
  *
- * Returns STUN servers always. Returns TURN credentials as well if
- * TURN_SECRET and TURN_URL are configured as environment variables.
+ * Returns STUN servers always. Returns TURN credentials as well when
+ * configured via environment variables.
  *
- * TURN credentials use the coturn REST API format (HMAC-SHA1 with a
- * shared secret), giving 24-hour time-limited tokens.
+ * Two TURN credential modes are supported:
+ *
+ * 1. Static credentials (Open Relay / Metered.ca):
+ *    TURN_URL, TURN_USERNAME, TURN_PASSWORD
+ *    Use this for openrelay.metered.ca or any service with static creds.
+ *
+ * 2. HMAC-SHA1 time-limited credentials (self-hosted coturn):
+ *    TURN_URL, TURN_SECRET
+ *    Generates 24-hour tokens using the coturn REST API format.
+ *
+ * Static mode takes precedence if both are configured.
  */
 
 const express = require('express');
@@ -19,20 +28,32 @@ const STUN_SERVERS = [
 
 // GET /api/chess/ice-servers — returns ICE server config for WebRTC
 router.get('/ice-servers', (req, res) => {
-  const turnSecret = process.env.TURN_SECRET;
   const turnUrl = process.env.TURN_URL;
+  const turnUsername = process.env.TURN_USERNAME;
+  const turnPassword = process.env.TURN_PASSWORD;
+  const turnSecret = process.env.TURN_SECRET;
 
-  if (!turnSecret || !turnUrl) {
+  if (!turnUrl) {
     return res.json(STUN_SERVERS);
   }
 
-  // Generate time-limited TURN credentials (expire in 24h)
-  const expiry = Math.floor(Date.now() / 1000) + 86400;
-  const username = String(expiry);
-  const credential = crypto
-    .createHmac('sha1', turnSecret)
-    .update(username)
-    .digest('base64');
+  let username, credential;
+
+  if (turnUsername && turnPassword) {
+    // Static credentials (Open Relay, Metered.ca, etc.)
+    username = turnUsername;
+    credential = turnPassword;
+  } else if (turnSecret) {
+    // HMAC-SHA1 time-limited credentials (coturn REST API format, expire in 24h)
+    const expiry = Math.floor(Date.now() / 1000) + 86400;
+    username = String(expiry);
+    credential = crypto
+      .createHmac('sha1', turnSecret)
+      .update(username)
+      .digest('base64');
+  } else {
+    return res.json(STUN_SERVERS);
+  }
 
   const servers = [
     ...STUN_SERVERS,


### PR DESCRIPTION
## Summary

- **Fix TURN auth**: `ice-servers.js` now supports static credentials (`TURN_USERNAME` + `TURN_PASSWORD`) for Open Relay / Metered.ca, in addition to the existing HMAC-SHA1 mode for coturn. Static mode takes precedence when both are configured.
- **Diagnostics improvement**: `diagnostics-html.js` now shows a WebRTC summary bar per session — TURN configured, relay candidate count (orange warning if 0 despite TURN), ICE state, connection state, and video received. Adds `webrtc` category colour (cyan) to the event legend.

## Root cause of video failure

The previous code generated HMAC-SHA1 time-limited credentials (coturn REST API format), but Open Relay's `staticauth.openrelay.metered.ca` expects static username/password from the Metered.ca dashboard. The credentials were rejected silently — `hasTurn: true` in diagnostics, but zero relay candidates gathered — causing ICE failure on mobile/NAT connections.

## Deployment

Set these env vars on the production server:
```
TURN_URL=staticauth.openrelay.metered.ca:443
TURN_USERNAME=<from Metered.ca dashboard>
TURN_PASSWORD=<from Metered.ca dashboard>
```
Remove `TURN_SECRET` (or leave unset) — it is no longer needed for Open Relay.

## Test plan
- [ ] Check `/api/chess/ice-servers` returns TURN entry with static username (not a timestamp)
- [ ] Start a multiplayer game across different networks and verify relay candidates appear
- [ ] Check `/api/chess/diagnostics/recent` HTML shows WebRTC summary with relay > 0 and TURN check mark
- [ ] Confirm remote video works between players