### PR TITLE
fix: resilient WS reconnect — fallback room scan and sessionRooms restore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chess-api",
-  "version": "1.16.0002",
+  "version": "1.17.0004",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-api",
-      "version": "1.16.0002",
+      "version": "1.17.0004",
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.17.0003",
+  "version": "1.17.0004",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -427,6 +427,9 @@ function attemptReconnect(ws, sessionId, room) {
   player.connected = true;
   player.disconnectedAt = null;
 
+  // Restore session→room mapping (defensive: handles edge cases where it was lost)
+  sessionRooms.set(sessionId, room.id);
+
   // Clear disconnect timer
   if (room.disconnectTimer) {
     clearTimeout(room.disconnectTimer);
@@ -531,6 +534,22 @@ function send(ws, type, payload) {
 function getRoomForSession(sessionId) {
   const roomId = sessionRooms.get(sessionId);
   return roomId ? rooms.get(roomId) : null;
+}
+
+/**
+ * Fallback room lookup by scanning all active rooms.
+ * Used when sessionRooms mapping is missing due to edge cases.
+ * Also restores the mapping if found.
+ */
+function findRoomBySession(sessionId) {
+  for (const room of rooms.values()) {
+    if (room.status !== 'playing' && room.status !== 'waiting') continue;
+    if (room.white?.sessionId === sessionId || room.black?.sessionId === sessionId) {
+      sessionRooms.set(sessionId, room.id);
+      return room;
+    }
+  }
+  return null;
 }
 
 function getRoomCount() {
@@ -743,6 +762,7 @@ module.exports = {
   handleReviewAnalysis,
   handleReviewExit,
   getRoomForSession,
+  findRoomBySession,
   getRoomCount,
   listRoomsForSession,
   cancelRoom,

--- a/ws.js
+++ b/ws.js
@@ -39,7 +39,11 @@ function initWebSocket(server) {
         sessionConnectionCount.set(sessionId, count + 1);
 
         // Check for existing room to reconnect
-        const existingRoom = rooms.getRoomForSession(sessionId);
+        let existingRoom = rooms.getRoomForSession(sessionId);
+        // Fallback: scan all rooms if sessionRooms mapping is missing
+        if (!existingRoom) {
+          existingRoom = rooms.findRoomBySession(sessionId);
+        }
         let reconnected = false;
         if (existingRoom && (existingRoom.status === 'playing' || existingRoom.status === 'waiting')) {
           const joinResult = rooms.joinRoom(ws, sessionId, null, existingRoom.id);


### PR DESCRIPTION
## Summary

- Add `findRoomBySession(sessionId)` fallback in `rooms.js` — scans all active rooms when `sessionRooms.get()` returns null
- Restore `sessionRooms.set(sessionId, room.id)` in `attemptReconnect()` as a defensive measure  
- Use `findRoomBySession` as fallback in `ws.js` auth handler so reconnecting players are always found

**Fixes:** During a live multiplayer game, WebSocket disconnect+reconnect caused server to return `auth_ok { inRoom: false }`, making the game unplayable even though the room was still active. Diagnosed from Game 630 diagnostics (iPhone Safari WS dropped for 1.1s, reconnected, but `sessionRooms` mapping was transiently missing).

## Test plan

- [x] Automated WS API test: connect two clients, start game, close WS on C1, reconnect — `auth_ok: inRoom=true` verified
- [x] `reconnect` message with full game state (FEN, color) received after reconnect
- [ ] Manual: open two tabs, start a game, run `mp.ws.close()` in DevTools, verify game stays alive vs. old "Game ended" behavior