### PR TITLE
Diagnostics Dashboard Navigation

### DIFF
--- a/db.js
+++ b/db.js
@@ -729,6 +729,20 @@ function getDiagnosticsRecent({ category, limit, offset } = {}) {
   return { gameId: row.game_id, events, count: events.length };
 }
 
+function getDiagnosticsRecentGames({ limit = 20 } = {}) {
+  return db.prepare(
+    `SELECT game_id, COUNT(*) as event_count,
+            MIN(timestamp) as first_ts, MAX(timestamp) as last_ts
+     FROM diagnostic_events WHERE game_id IS NOT NULL
+     GROUP BY game_id ORDER BY game_id DESC LIMIT ?`
+  ).all(limit).map(r => ({
+    gameId: r.game_id,
+    eventCount: r.event_count,
+    firstTs: r.first_ts,
+    lastTs: r.last_ts,
+  }));
+}
+
 function cleanupOldDiagnostics(maxAgeDays = 30) {
   const cutoff = Date.now() - (maxAgeDays * 24 * 60 * 60 * 1000);
   const info = db.prepare('DELETE FROM diagnostic_events WHERE created_at < ?').run(cutoff);
@@ -796,5 +810,6 @@ module.exports = {
   getDiagnosticsByRoom,
   getDiagnosticsBySession,
   getDiagnosticsRecent,
+  getDiagnosticsRecentGames,
   cleanupOldDiagnostics,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.17.0004",
+  "version": "1.17.0005",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.17.0005",
+  "version": "1.17.0006",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.17.0003",
+  "version": "1.17.0004",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -192,7 +192,7 @@ function renderGamesNav(recentGames, currentGameId) {
     if (isCurrent) {
       return `<span class="game-nav-item game-nav-current" title="Currently viewing">${escapeHtml(label)}</span>`;
     }
-    return `<a class="game-nav-item" href="/api/chess/diagnostics/game/${g.gameId}">${escapeHtml(label)}</a>`;
+    return `<a class="game-nav-item" href="/api/chess/diagnostics?gameId=${g.gameId}">${escapeHtml(label)}</a>`;
   }).join('');
 
   return `<div class="games-nav">
@@ -307,6 +307,7 @@ function renderDiagnosticsHTML(result, context, recentGames = []) {
     <div class="header-meta">${escapeHtml(ctxLabel)}</div>
   </div>
   <div class="header-actions">
+    ${result.gameId ? `<button class="btn" id="api-link-btn" onclick="copyApiLink()">⧉ Copy API link</button>` : ''}
     <button class="btn" onclick="location.reload()">↻ Refresh</button>
   </div>
 </div>
@@ -337,6 +338,18 @@ ${events.length > 0 ? `<div class="legend">${categoryLegend(events)}</div>` : ''
 
 <script>
 var _json = ${JSON.stringify(JSON.stringify(result))};
+var _gameId = ${result.gameId ? result.gameId : 'null'};
+function copyApiLink() {
+  var url = location.origin + '/api/chess/diagnostics/game/' + _gameId;
+  navigator.clipboard.writeText(url).then(function() {
+    var btn = document.getElementById('api-link-btn');
+    btn.textContent = '✓ Copied!';
+    setTimeout(function() { btn.textContent = '⧉ Copy API link'; }, 2000);
+  }).catch(function() {
+    var btn = document.getElementById('api-link-btn');
+    btn.textContent = 'Copy failed';
+  });
+}
 function copyJson() {
   navigator.clipboard.writeText(_json).then(function() {
     var btn = document.getElementById('copy-btn');

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -183,7 +183,25 @@ function renderSessionSection(sessionId, events) {
 </details>`;
 }
 
-function renderDiagnosticsHTML(result, context) {
+function renderGamesNav(recentGames, currentGameId) {
+  if (!recentGames || recentGames.length === 0) return '';
+
+  const items = recentGames.map(g => {
+    const isCurrent = g.gameId === currentGameId;
+    const label = `#${g.gameId} · ${g.eventCount} event${g.eventCount !== 1 ? 's' : ''} · ${formatTs(g.lastTs)}`;
+    if (isCurrent) {
+      return `<span class="game-nav-item game-nav-current" title="Currently viewing">${escapeHtml(label)}</span>`;
+    }
+    return `<a class="game-nav-item" href="/api/chess/diagnostics/game/${g.gameId}">${escapeHtml(label)}</a>`;
+  }).join('');
+
+  return `<div class="games-nav">
+  <span class="games-nav-label">GAMES</span>
+  <div class="games-nav-list">${items}</div>
+</div>`;
+}
+
+function renderDiagnosticsHTML(result, context, recentGames = []) {
   const { events = [], count = 0 } = result;
   const ctxLabel = context || `Game ${result.gameId}`;
   const firstTs = events.length ? events[0].timestamp : null;
@@ -217,9 +235,13 @@ function renderDiagnosticsHTML(result, context) {
   .stat-label { font-size: 10px; text-transform: uppercase; letter-spacing: .08em; color: #64748b; }
   .stat-value { font-size: 15px; font-weight: 600; color: #f1f5f9; }
 
-  /* Nav */
-  .nav { padding: 10px 24px; border-bottom: 1px solid #1e293b; font-size: 11px; color: #475569; display: flex; gap: 12px; flex-wrap: wrap; }
-  .nav a { color: #60a5fa; }
+  /* Games nav */
+  .games-nav { padding: 10px 24px; border-bottom: 1px solid #334155; background: #0f172a; display: flex; align-items: flex-start; gap: 12px; }
+  .games-nav-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: #475569; white-space: nowrap; padding-top: 3px; }
+  .games-nav-list { display: flex; flex-wrap: wrap; gap: 6px; }
+  .game-nav-item { font-size: 11px; padding: 3px 10px; border-radius: 999px; border: 1px solid #334155; color: #94a3b8; text-decoration: none; white-space: nowrap; }
+  .game-nav-item:hover { background: #1e293b; color: #e2e8f0; border-color: #475569; }
+  .game-nav-current { background: #1e3a5f; border-color: #3b82f6; color: #60a5fa; cursor: default; }
 
   /* Legend */
   .legend { padding: 8px 24px 12px; display: flex; gap: 12px; flex-wrap: wrap; border-bottom: 1px solid #1e293b; }
@@ -297,13 +319,7 @@ function renderDiagnosticsHTML(result, context) {
   <div class="stat"><span class="stat-label">Time range</span><span class="stat-value" style="font-size:12px">${timeRange}</span></div>
 </div>
 
-<div class="nav">
-  <a href="?">Recent game</a>
-  <span>|</span>
-  <span>Game: /api/chess/diagnostics/game/:id</span>
-  <span>Room: /api/chess/diagnostics/room/:code</span>
-  <span>Session: /api/chess/diagnostics/session/:id</span>
-</div>
+${renderGamesNav(recentGames, result.gameId)}
 
 ${events.length > 0 ? `<div class="legend">${categoryLegend(events)}</div>` : ''}
 

--- a/routes/diagnostics.js
+++ b/routes/diagnostics.js
@@ -6,6 +6,7 @@ const {
   getDiagnosticsByRoom,
   getDiagnosticsBySession,
   getDiagnosticsRecent,
+  getDiagnosticsRecentGames,
 } = require('../db');
 const { renderDiagnosticsHTML } = require('./diagnostics-html');
 
@@ -37,6 +38,25 @@ router.post('/diagnostics', (req, res) => {
     res.status(204).end();
   } catch (e) {
     console.error('POST /diagnostics error:', e.message);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// GET /api/chess/diagnostics — HTML dashboard showing the most recent game
+router.get('/diagnostics', (req, res) => {
+  try {
+    const { category, limit = 500, offset = 0 } = req.query;
+    const result = getDiagnosticsRecent({
+      category: category || null,
+      limit: Math.min(parseInt(limit, 10) || 500, 1000),
+      offset: parseInt(offset, 10) || 0,
+    });
+    if (result.gameId === null) return res.status(404).send('<p>No game diagnostics found.</p>');
+
+    const recentGames = getDiagnosticsRecentGames();
+    return res.send(renderDiagnosticsHTML(result, `Recent game (ID ${result.gameId})`, recentGames));
+  } catch (e) {
+    console.error('GET /diagnostics error:', e.message);
     res.status(500).json({ error: e.message });
   }
 });

--- a/routes/diagnostics.js
+++ b/routes/diagnostics.js
@@ -75,7 +75,7 @@ router.get('/diagnostics/game/:id', (req, res) => {
     });
     const result = { gameId, events, count: events.length };
 
-    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Game ${gameId}`));
+    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Game ${gameId}`, getDiagnosticsRecentGames()));
     res.json(result);
   } catch (e) {
     console.error('GET /diagnostics/game/:id error:', e.message);
@@ -95,7 +95,7 @@ router.get('/diagnostics/room/:code', (req, res) => {
     });
     const result = { roomCode, events, count: events.length };
 
-    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Room ${roomCode}`));
+    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Room ${roomCode}`, getDiagnosticsRecentGames()));
     res.json(result);
   } catch (e) {
     console.error('GET /diagnostics/room/:code error:', e.message);
@@ -115,7 +115,7 @@ router.get('/diagnostics/session/:id', (req, res) => {
     });
     const result = { sessionId, events, count: events.length };
 
-    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Session ${sessionId.slice(0, 8)}…`));
+    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Session ${sessionId.slice(0, 8)}…`, getDiagnosticsRecentGames()));
     res.json(result);
   } catch (e) {
     console.error('GET /diagnostics/session/:id error:', e.message);
@@ -134,7 +134,7 @@ router.get('/diagnostics/recent', (req, res) => {
     });
     if (result.gameId === null) return res.status(404).json({ error: 'No game diagnostics found' });
 
-    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Recent game (ID ${result.gameId})`));
+    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Recent game (ID ${result.gameId})`, getDiagnosticsRecentGames()));
     res.json(result);
   } catch (e) {
     console.error('GET /diagnostics/recent error:', e.message);

--- a/routes/diagnostics.js
+++ b/routes/diagnostics.js
@@ -42,19 +42,29 @@ router.post('/diagnostics', (req, res) => {
   }
 });
 
-// GET /api/chess/diagnostics — HTML dashboard showing the most recent game
+// GET /api/chess/diagnostics — HTML dashboard (most recent game, or ?gameId=N for a specific game)
 router.get('/diagnostics', (req, res) => {
   try {
-    const { category, limit = 500, offset = 0 } = req.query;
-    const result = getDiagnosticsRecent({
+    const { category, limit = 500, offset = 0, gameId: gameIdParam } = req.query;
+    const queryOpts = {
       category: category || null,
       limit: Math.min(parseInt(limit, 10) || 500, 1000),
       offset: parseInt(offset, 10) || 0,
-    });
-    if (result.gameId === null) return res.status(404).send('<p>No game diagnostics found.</p>');
+    };
+
+    let result;
+    if (gameIdParam) {
+      const gameId = parseInt(gameIdParam, 10);
+      if (isNaN(gameId)) return res.status(400).send('<p>Invalid game ID.</p>');
+      const events = getDiagnosticsByGame(gameId, queryOpts);
+      result = { gameId, events, count: events.length };
+    } else {
+      result = getDiagnosticsRecent(queryOpts);
+      if (result.gameId === null) return res.status(404).send('<p>No game diagnostics found.</p>');
+    }
 
     const recentGames = getDiagnosticsRecentGames();
-    return res.send(renderDiagnosticsHTML(result, `Recent game (ID ${result.gameId})`, recentGames));
+    return res.send(renderDiagnosticsHTML(result, `Game ${result.gameId}`, recentGames));
   } catch (e) {
     console.error('GET /diagnostics error:', e.message);
     res.status(500).json({ error: e.message });
@@ -75,7 +85,6 @@ router.get('/diagnostics/game/:id', (req, res) => {
     });
     const result = { gameId, events, count: events.length };
 
-    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Game ${gameId}`, getDiagnosticsRecentGames()));
     res.json(result);
   } catch (e) {
     console.error('GET /diagnostics/game/:id error:', e.message);
@@ -95,7 +104,6 @@ router.get('/diagnostics/room/:code', (req, res) => {
     });
     const result = { roomCode, events, count: events.length };
 
-    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Room ${roomCode}`, getDiagnosticsRecentGames()));
     res.json(result);
   } catch (e) {
     console.error('GET /diagnostics/room/:code error:', e.message);
@@ -115,7 +123,6 @@ router.get('/diagnostics/session/:id', (req, res) => {
     });
     const result = { sessionId, events, count: events.length };
 
-    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Session ${sessionId.slice(0, 8)}…`, getDiagnosticsRecentGames()));
     res.json(result);
   } catch (e) {
     console.error('GET /diagnostics/session/:id error:', e.message);
@@ -134,7 +141,6 @@ router.get('/diagnostics/recent', (req, res) => {
     });
     if (result.gameId === null) return res.status(404).json({ error: 'No game diagnostics found' });
 
-    if (req.accepts('html')) return res.send(renderDiagnosticsHTML(result, `Recent game (ID ${result.gameId})`, getDiagnosticsRecentGames()));
     res.json(result);
   } catch (e) {
     console.error('GET /diagnostics/recent error:', e.message);


### PR DESCRIPTION
## Summary

- Add `GET /api/chess/diagnostics` as the new HTML dashboard (formerly `/diagnostics/recent`)
- Dashboard supports `?gameId=N` to view a specific game
- Add games nav bar showing up to 20 recent games as clickable pills (current highlighted blue)
- Add Copy API link button to copy the JSON endpoint URL for the current game
- All sub-endpoints (`/recent`, `/game/:id`, `/room/:code`, `/session/:id`) are now JSON-only
- Add `getDiagnosticsRecentGames()` DB helper

## Test plan

- [ ] `GET /api/chess/diagnostics` returns HTML dashboard with games nav
- [ ] `GET /api/chess/diagnostics?gameId=N` loads the specified game, highlights it in nav
- [ ] Clicking a nav pill stays on the dashboard with the game changing
- [ ] Copy API link button copies the correct JSON endpoint URL
- [ ] `GET /api/chess/diagnostics/recent` returns JSON only
- [ ] `GET /api/chess/diagnostics/game/:id` returns JSON only