### PR TITLE
Diagnostics: color-coded game selection pills

### DIFF
--- a/db.js
+++ b/db.js
@@ -731,15 +731,56 @@ function getDiagnosticsRecent({ category, limit, offset } = {}) {
 
 function getDiagnosticsRecentGames({ limit = 20 } = {}) {
   return db.prepare(
-    `SELECT game_id, COUNT(*) as event_count,
-            MIN(timestamp) as first_ts, MAX(timestamp) as last_ts
-     FROM diagnostic_events WHERE game_id IS NOT NULL
-     GROUP BY game_id ORDER BY game_id DESC LIMIT ?`
+    `SELECT d.game_id, COUNT(d.id) as event_count,
+            MIN(d.timestamp) as first_ts, MAX(d.timestamp) as last_ts,
+            g.result, g.result_reason, g.end_time,
+            (SELECT COUNT(*) FROM moves m WHERE m.game_id = d.game_id) as move_count
+     FROM diagnostic_events d
+     LEFT JOIN games g ON g.id = d.game_id
+     WHERE d.game_id IS NOT NULL
+     GROUP BY d.game_id ORDER BY d.game_id DESC LIMIT ?`
   ).all(limit).map(r => ({
     gameId: r.game_id,
     eventCount: r.event_count,
     firstTs: r.first_ts,
     lastTs: r.last_ts,
+    result: r.result || null,
+    resultReason: r.result_reason || null,
+    endTime: r.end_time || null,
+    moveCount: r.move_count || 0,
+  }));
+}
+
+function getGameSessionStates(gameId) {
+  // Get top-2 sessions by most recent activity for the game
+  const sessions = db.prepare(
+    `SELECT session_id, MAX(timestamp) as last_ts
+     FROM diagnostic_events WHERE game_id = ?
+     GROUP BY session_id ORDER BY last_ts DESC LIMIT 2`
+  ).all(gameId);
+
+  // Get all recent webrtc state-change events for this game, newest first
+  const webrtcEvents = db.prepare(
+    `SELECT session_id, event_type, data, timestamp
+     FROM diagnostic_events
+     WHERE game_id = ? AND category = 'webrtc'
+       AND event_type IN ('connection_state_change', 'ice_state_change')
+     ORDER BY timestamp DESC`
+  ).all(gameId);
+
+  // Build per-session map with last connection state
+  const stateBySession = new Map();
+  for (const e of webrtcEvents) {
+    if (!stateBySession.has(e.session_id)) {
+      const d = JSON.parse(e.data || '{}');
+      stateBySession.set(e.session_id, d.state || null);
+    }
+  }
+
+  return sessions.map(s => ({
+    sessionId: s.session_id,
+    lastTs: s.last_ts,
+    connectionState: stateBySession.get(s.session_id) || null,
   }));
 }
 
@@ -811,5 +852,6 @@ module.exports = {
   getDiagnosticsBySession,
   getDiagnosticsRecent,
   getDiagnosticsRecentGames,
+  getGameSessionStates,
   cleanupOldDiagnostics,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.18.0001",
+  "version": "1.18.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -1,5 +1,44 @@
 'use strict';
 
+// --- Pill status ---
+
+const ONGOING_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+const PILL_COLORS = {
+  complete:          { border: '#22c55e', bg: '#14532d', activeBg: '#166534', text: '#4ade80' },
+  abandoned:         { border: '#eab308', bg: '#422006', activeBg: '#713f12', text: '#fbbf24' },
+  connection_failed: { border: '#ef4444', bg: '#450a0a', activeBg: '#7f1d1d', text: '#f87171' },
+  ongoing:           { border: '#3b82f6', bg: '#0c2340', activeBg: '#1d4ed8', text: '#60a5fa' },
+};
+
+function computePillStatus(game) {
+  const { result, resultReason, moveCount, lastTs } = game;
+  if (result === null) {
+    return (Date.now() - (lastTs || 0)) < ONGOING_THRESHOLD_MS ? 'ongoing' : 'connection_failed';
+  }
+  if (resultReason === 'abandoned') return 'connection_failed';
+  if ((moveCount || 0) <= 2 || resultReason === 'resignation') return 'abandoned';
+  return 'complete';
+}
+
+const DOT_RECENT_MS = 5  * 60 * 1000; // 5 min — actively connected
+const DOT_GRACE_MS  = 30 * 60 * 1000; // 30 min — grace period
+
+function computeDotColor(sessionState) {
+  const { connectionState, lastTs } = sessionState;
+  const age = Date.now() - (lastTs || 0);
+  const connected    = connectionState === 'connected' || connectionState === 'completed';
+  const disconnected = connectionState === 'disconnected' || connectionState === 'failed' || connectionState === 'closed';
+
+  if (connected && age < DOT_RECENT_MS) return '#4ade80'; // green — actively connected
+  if (connected && age < DOT_GRACE_MS)  return '#fbbf24'; // yellow — was connected, grace period
+  if (disconnected)                      return '#f87171'; // red — explicitly disconnected
+  if (age < DOT_GRACE_MS)               return '#fbbf24'; // yellow — no state, still recent
+  return '#f87171';                                        // red — stale / no activity
+}
+
+// --- Category colors ---
+
 const CATEGORY_COLORS = {
   lifecycle: '#3b82f6',
   error:     '#ef4444',
@@ -183,22 +222,47 @@ function renderSessionSection(sessionId, events) {
 </details>`;
 }
 
+function renderConnectionDots(sessionStates) {
+  if (!sessionStates || sessionStates.length === 0) return '';
+  return sessionStates.slice(0, 2).map(s => {
+    const color = computeDotColor(s);
+    const title = `Session ${String(s.sessionId).slice(0, 8)}… · state: ${s.connectionState || 'unknown'}`;
+    return `<span class="conn-dot" style="background:${color}" title="${escapeHtml(title)}"></span>`;
+  }).join('');
+}
+
 function renderGamesNav(recentGames, currentGameId) {
   if (!recentGames || recentGames.length === 0) return '';
 
   const items = recentGames.map(g => {
     const isCurrent = g.gameId === currentGameId;
+    const status = computePillStatus(g);
+    const colors = PILL_COLORS[status];
     const label = `#${g.gameId} · ${g.eventCount} event${g.eventCount !== 1 ? 's' : ''} · ${formatTs(g.lastTs)}`;
+
+    const dots = status === 'ongoing' ? renderConnectionDots(g.sessionStates) : '';
+    const pillBg = isCurrent ? colors.activeBg : colors.bg;
+    const inlineStyle = `background:${pillBg};border-color:${colors.border};color:${colors.text};`;
+
     if (isCurrent) {
-      return `<span class="game-nav-item game-nav-current" title="Currently viewing">${escapeHtml(label)}</span>`;
+      return `<span class="game-nav-item game-nav-current" style="${inlineStyle}" title="Currently viewing">${dots}${escapeHtml(label)}</span>`;
     }
-    return `<a class="game-nav-item" href="/api/chess/diagnostics?gameId=${g.gameId}">${escapeHtml(label)}</a>`;
+    return `<a class="game-nav-item" href="/api/chess/diagnostics?gameId=${g.gameId}" style="${inlineStyle}">${dots}${escapeHtml(label)}</a>`;
   }).join('');
+
+  const legend = `<div class="pill-legend">
+    <span class="pill-legend-item" style="color:#4ade80">■ complete</span>
+    <span class="pill-legend-item" style="color:#fbbf24">■ abandoned / short</span>
+    <span class="pill-legend-item" style="color:#f87171">■ conn. failed</span>
+    <span class="pill-legend-item" style="color:#60a5fa">■ ongoing</span>
+    <span class="pill-legend-item" style="color:#94a3b8">· dots = player conn. status</span>
+  </div>`;
 
   return `<div class="games-nav">
   <span class="games-nav-label">GAMES</span>
   <div class="games-nav-list">${items}</div>
-</div>`;
+</div>
+${legend}`;
 }
 
 function renderDiagnosticsHTML(result, context, recentGames = []) {
@@ -239,9 +303,12 @@ function renderDiagnosticsHTML(result, context, recentGames = []) {
   .games-nav { padding: 10px 24px; border-bottom: 1px solid #334155; background: #0f172a; display: flex; align-items: flex-start; gap: 12px; }
   .games-nav-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: #475569; white-space: nowrap; padding-top: 3px; }
   .games-nav-list { display: flex; flex-wrap: wrap; gap: 6px; }
-  .game-nav-item { font-size: 11px; padding: 3px 10px; border-radius: 999px; border: 1px solid #334155; color: #94a3b8; text-decoration: none; white-space: nowrap; }
-  .game-nav-item:hover { background: #1e293b; color: #e2e8f0; border-color: #475569; }
-  .game-nav-current { background: #1e3a5f; border-color: #3b82f6; color: #60a5fa; cursor: default; }
+  .game-nav-item { font-size: 11px; padding: 3px 10px; border-radius: 999px; border: 1px solid transparent; text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 5px; }
+  .game-nav-item:hover { filter: brightness(1.25); }
+  .game-nav-current { cursor: default; }
+  .conn-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
+  .pill-legend { padding: 4px 24px 8px; display: flex; gap: 14px; flex-wrap: wrap; border-bottom: 1px solid #1e293b; }
+  .pill-legend-item { font-size: 10px; white-space: nowrap; }
 
   /* Legend */
   .legend { padding: 8px 24px 12px; display: flex; gap: 12px; flex-wrap: wrap; border-bottom: 1px solid #1e293b; }

--- a/routes/diagnostics.js
+++ b/routes/diagnostics.js
@@ -7,6 +7,7 @@ const {
   getDiagnosticsBySession,
   getDiagnosticsRecent,
   getDiagnosticsRecentGames,
+  getGameSessionStates,
 } = require('../db');
 const { renderDiagnosticsHTML } = require('./diagnostics-html');
 
@@ -64,7 +65,12 @@ router.get('/diagnostics', (req, res) => {
     }
 
     const recentGames = getDiagnosticsRecentGames();
-    return res.send(renderDiagnosticsHTML(result, `Game ${result.gameId}`, recentGames));
+    const recentGamesWithStates = recentGames.map(g =>
+      g.result === null
+        ? { ...g, sessionStates: getGameSessionStates(g.gameId) }
+        : g
+    );
+    return res.send(renderDiagnosticsHTML(result, `Game ${result.gameId}`, recentGamesWithStates));
   } catch (e) {
     console.error('GET /diagnostics error:', e.message);
     res.status(500).json({ error: e.message });


### PR DESCRIPTION
## Summary

- Color-code game pills in the diagnostics dashboard games nav strip for instant visual triage
- Green: complete game (checkmate/stalemate/draw/timeout, >=3 moves)
- Yellow: user resigned (resign button) or game had <=2 moves (trivial/aborted)
- Red: connection failure - result_reason='abandoned' (disconnect timeout) or game has no result and is stale (>2h old)
- Blue: ongoing game - with two colored connection-status dots per player (green/yellow/red WebRTC state)
- Added pill legend row below the games nav

## Changes

- db.js: getDiagnosticsRecentGames now JOINs games table for result/reason/move count; new getGameSessionStates(gameId) for WebRTC state per player session
- routes/diagnostics.js: attaches sessionStates for ongoing games before HTML render
- routes/diagnostics-html.js: computePillStatus, computeDotColor, colored inline styles, connection dots, pill legend, updated CSS

## Test plan

- [x] 8/8 automated status logic cases passing
- [ ] Open /api/chess/diagnostics - pills show colored
- [ ] Legend row visible below pills
- [ ] Click different game pills - navigate correctly with color preserved

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-Diagnostics-Game-Pill-Colors