### PR TITLE
feat: King Cam camMode support

### DIFF
--- a/matchmaking.js
+++ b/matchmaking.js
@@ -5,9 +5,10 @@ const queues = new Map();
 
 const DEFAULT_TC = '5+0';
 
-function joinQueue(ws, sessionId, name, timeControl, videoEnabled, chess960) {
+function joinQueue(ws, sessionId, name, timeControl, camMode, chess960) {
   const tc = timeControl || DEFAULT_TC;
-  const wantsVideo = !!videoEnabled;
+  const effectiveCamMode = ['none', 'king-cam', 'board-face'].includes(camMode) ? camMode : 'none';
+  const wantsVideo = effectiveCamMode !== 'none';
 
   // Check if already in a queue
   for (const [, q] of queues) {
@@ -25,7 +26,7 @@ function joinQueue(ws, sessionId, name, timeControl, videoEnabled, chess960) {
   }
 
   const wantsChess960 = !!chess960;
-  const player = { ws, sessionId, name: name || 'Opponent', videoEnabled: wantsVideo, chess960: wantsChess960 };
+  const player = { ws, sessionId, name: name || 'Opponent', camMode: effectiveCamMode, videoEnabled: wantsVideo, chess960: wantsChess960 };
 
   // Try to find a match (video and chess960 preferences must match)
   const match = findMatch(tc, wantsVideo, wantsChess960);
@@ -36,7 +37,7 @@ function joinQueue(ws, sessionId, name, timeControl, videoEnabled, chess960) {
     if (!opponent.ws || opponent.ws.readyState !== 1) {
       // Opponent disconnected, remove them and retry
       removeFromQueue(opponent.sessionId);
-      return joinQueue(ws, sessionId, name, timeControl, videoEnabled, chess960);
+      return joinQueue(ws, sessionId, name, timeControl, camMode, chess960);
     }
 
     // Match found — create a room with randomly assigned colors
@@ -44,9 +45,10 @@ function joinQueue(ws, sessionId, name, timeControl, videoEnabled, chess960) {
     const whitePlayer = creatorIsWhite ? opponent : player;
     const blackPlayer = creatorIsWhite ? player : opponent;
 
-    const matchVideoEnabled = wantsVideo && opponent.videoEnabled;
+    // Use cam mode only if both players want video; prefer the joiner's cam mode
+    const matchCamMode = (wantsVideo && opponent.videoEnabled) ? (player.camMode || opponent.camMode) : 'none';
     const matchChess960 = wantsChess960 && opponent.chess960;
-    const room = rooms.createRoom(whitePlayer.ws, whitePlayer.sessionId, whitePlayer.name, matchTc, matchVideoEnabled, matchChess960);
+    const room = rooms.createRoom(whitePlayer.ws, whitePlayer.sessionId, whitePlayer.name, matchTc, matchCamMode, matchChess960);
     rooms.joinRoom(blackPlayer.ws, blackPlayer.sessionId, blackPlayer.name, room.id);
   } else {
     // No match — add to queue

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.20.0000",
+  "version": "1.20.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -57,7 +57,7 @@ function parseTimeControl(tc) {
   return { minutes: parseInt(match[1], 10), increment: parseInt(match[2], 10) };
 }
 
-function createRoom(ws, sessionId, name, timeControl, videoEnabled, chess960) {
+function createRoom(ws, sessionId, name, timeControl, camMode, chess960) {
   const roomId = generateRoomCode();
   // "any" defaults to 5+0 for room creation
   const effectiveTc = timeControl === 'any' ? '5+0' : timeControl;
@@ -66,6 +66,7 @@ function createRoom(ws, sessionId, name, timeControl, videoEnabled, chess960) {
 
   const is960 = !!chess960;
   const startFen = is960 ? generateChess960FEN() : undefined;
+  const effectiveCamMode = ['none', 'king-cam', 'board-face'].includes(camMode) ? camMode : 'none';
 
   const room = {
     id: roomId,
@@ -80,14 +81,15 @@ function createRoom(ws, sessionId, name, timeControl, videoEnabled, chess960) {
     dbGameId: null,
     createdAt: Date.now(),
     cleanupTimer: null,
-    videoEnabled: !!videoEnabled,
+    camMode: effectiveCamMode,
+    videoEnabled: effectiveCamMode !== 'none', // backward compat
     chess960: is960,
   };
 
   rooms.set(roomId, room);
   sessionRooms.set(sessionId, roomId);
 
-  send(ws, 'room_created', { roomId, color: 'w', videoEnabled: room.videoEnabled });
+  send(ws, 'room_created', { roomId, color: 'w', camMode: room.camMode, videoEnabled: room.videoEnabled });
   return room;
 }
 
@@ -151,8 +153,8 @@ function joinRoom(ws, sessionId, name, roomId) {
     dbGameId: room.dbGameId,
   };
 
-  send(room.white.ws, 'game_start', { ...startPayload, color: 'w', opponentName: room.black.name, videoEnabled: room.videoEnabled });
-  send(room.black.ws, 'game_start', { ...startPayload, color: 'b', opponentName: room.white.name, videoEnabled: room.videoEnabled });
+  send(room.white.ws, 'game_start', { ...startPayload, color: 'w', opponentName: room.black.name, camMode: room.camMode, videoEnabled: room.videoEnabled });
+  send(room.black.ws, 'game_start', { ...startPayload, color: 'b', opponentName: room.white.name, camMode: room.camMode, videoEnabled: room.videoEnabled });
 
   return room;
 }
@@ -449,6 +451,7 @@ function attemptReconnect(ws, sessionId, room) {
     clocks: clockPayload,
     opponentName: getPlayerBySide(room, side === 'w' ? 'b' : 'w').name,
     opponentConnected: getPlayerBySide(room, side === 'w' ? 'b' : 'w').connected,
+    camMode: room.camMode,
     videoEnabled: room.videoEnabled,
     chess960: room.chess960,
     dbGameId: room.dbGameId,

--- a/ws.js
+++ b/ws.js
@@ -63,7 +63,7 @@ function initWebSocket(server) {
       // Route messages
       switch (type) {
         case 'create_room':
-          rooms.createRoom(ws, sessionId, payload?.name, payload?.timeControl, payload?.videoEnabled, payload?.chess960);
+          rooms.createRoom(ws, sessionId, payload?.name, payload?.timeControl, payload?.camMode ?? (payload?.videoEnabled ? 'board-face' : 'none'), payload?.chess960);
           break;
 
         case 'join_room':
@@ -75,7 +75,7 @@ function initWebSocket(server) {
           break;
 
         case 'quick_match':
-          matchmaking.joinQueue(ws, sessionId, payload?.name, payload?.timeControl, payload?.videoEnabled, payload?.chess960);
+          matchmaking.joinQueue(ws, sessionId, payload?.name, payload?.timeControl, payload?.camMode ?? (payload?.videoEnabled ? 'board-face' : 'none'), payload?.chess960);
           break;
 
         case 'cancel_queue':


### PR DESCRIPTION
## Summary

- Pass `camMode` string (`'none' | 'king-cam' | 'board-face'`) through WebSocket message flow
- Backward compatible: old clients sending `videoEnabled` boolean are handled via fallback
- `rooms.js`: stores `camMode` on room, broadcasts in `game_start` payload
- `matchmaking.js`: resolves match `camMode` (joiner's preference wins when both want video)
- `ws.js`: extracts `camMode` from WS messages with `videoEnabled` fallback

## Test plan

- [ ] `quick_match` with `camMode: 'king-cam'` → `game_start` payload contains `camMode: 'king-cam'`
- [ ] `create_room` + `join_room` with `camMode: 'board-face'` → `game_start` contains `camMode: 'board-face'`
- [ ] Old client with `videoEnabled: true` (no `camMode`) → treated as `board-face`
- [ ] Matchmaking: two players with video prefs matched → `matchCamMode` resolved correctly