### PR TITLE
feat: Issue reporting API and diagnostics integration

### DIFF
--- a/db.js
+++ b/db.js
@@ -198,6 +198,25 @@ function initDb() {
     CREATE INDEX IF NOT EXISTS idx_diag_created_at ON diagnostic_events(created_at);
   `);
 
+  // --- Issue reports table ---
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS issue_reports (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      game_id         INTEGER REFERENCES games(id) ON DELETE SET NULL,
+      session_id      TEXT NOT NULL,
+      categories      TEXT NOT NULL DEFAULT '[]',
+      description     TEXT NOT NULL DEFAULT '',
+      auto_detected   INTEGER NOT NULL DEFAULT 0,
+      device_info     TEXT NOT NULL DEFAULT '{}',
+      created_at      INTEGER NOT NULL,
+      updated_at      INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_issue_reports_game_id ON issue_reports(game_id);
+    CREATE INDEX IF NOT EXISTS idx_issue_reports_session_id ON issue_reports(session_id);
+    CREATE INDEX IF NOT EXISTS idx_issue_reports_created_at ON issue_reports(created_at);
+  `);
+
   return db;
 }
 
@@ -792,6 +811,59 @@ function cleanupOldDiagnostics(maxAgeDays = 30) {
   }
 }
 
+// --- Issue report helpers ---
+
+function createIssueReport(gameId, sessionId, autoDetected, deviceInfo) {
+  const now = Date.now();
+  const stmt = db.prepare(`
+    INSERT INTO issue_reports (game_id, session_id, auto_detected, device_info, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+  const info = stmt.run(gameId || null, sessionId, autoDetected ? 1 : 0, JSON.stringify(deviceInfo || {}), now, now);
+  return { id: info.lastInsertRowid, gameId, sessionId, autoDetected, createdAt: now };
+}
+
+function updateIssueReport(id, fields) {
+  const sets = ['updated_at = ?'];
+  const values = [Date.now()];
+
+  if (fields.categories !== undefined) {
+    sets.push('categories = ?');
+    values.push(JSON.stringify(fields.categories));
+  }
+  if (fields.description !== undefined) {
+    sets.push('description = ?');
+    values.push(fields.description);
+  }
+
+  values.push(id);
+  db.prepare(`UPDATE issue_reports SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+}
+
+function getIssueReportByGame(gameId) {
+  const row = db.prepare('SELECT * FROM issue_reports WHERE game_id = ? ORDER BY created_at DESC LIMIT 1').get(gameId);
+  return row ? formatIssueReport(row) : null;
+}
+
+function getIssueReport(id) {
+  const row = db.prepare('SELECT * FROM issue_reports WHERE id = ?').get(id);
+  return row ? formatIssueReport(row) : null;
+}
+
+function formatIssueReport(row) {
+  return {
+    id: row.id,
+    gameId: row.game_id,
+    sessionId: row.session_id,
+    categories: JSON.parse(row.categories || '[]'),
+    description: row.description,
+    autoDetected: !!row.auto_detected,
+    deviceInfo: JSON.parse(row.device_info || '{}'),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
 function formatDiagnosticEvent(row) {
   return {
     id: row.id,
@@ -854,4 +926,9 @@ module.exports = {
   getDiagnosticsRecentGames,
   getGameSessionStates,
   cleanupOldDiagnostics,
+  // Issue report helpers
+  createIssueReport,
+  updateIssueReport,
+  getIssueReportByGame,
+  getIssueReport,
 };

--- a/db.js
+++ b/db.js
@@ -845,6 +845,11 @@ function getIssueReportByGame(gameId) {
   return row ? formatIssueReport(row) : null;
 }
 
+function getIssueReportsByGame(gameId) {
+  const rows = db.prepare('SELECT * FROM issue_reports WHERE game_id = ? ORDER BY created_at ASC').all(gameId);
+  return rows.map(formatIssueReport);
+}
+
 function getIssueReport(id) {
   const row = db.prepare('SELECT * FROM issue_reports WHERE id = ?').get(id);
   return row ? formatIssueReport(row) : null;
@@ -930,5 +935,6 @@ module.exports = {
   createIssueReport,
   updateIssueReport,
   getIssueReportByGame,
+  getIssueReportsByGame,
   getIssueReport,
 };

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const gameHistoryRouter = require('./routes/game-history');
 const roomsRouter = require('./routes/rooms');
 const iceServersRouter = require('./routes/ice-servers');
 const diagnosticsRouter = require('./routes/diagnostics');
+const issuesRouter = require('./routes/issues');
 const { initWebSocket } = require('./ws');
 const { version } = require('./package.json');
 const { cleanupOldDiagnostics } = require('./db');
@@ -51,6 +52,7 @@ app.use('/api/chess', gameHistoryRouter);
 app.use('/api/chess', roomsRouter);
 app.use('/api/chess', iceServersRouter);
 app.use('/api/chess', diagnosticsRouter);
+app.use('/api/chess', issuesRouter);
 
 // SPA catch-all: serve index.html for non-API, non-static paths
 // This allows path-based URLs (/replay, /games) to load the app,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.21.0000",
+  "version": "1.21.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.21.0001",
+  "version": "1.21.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.21.0002",
+  "version": "1.21.0003",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -272,6 +272,44 @@ function renderMovesSection(game) {
 </details>`;
 }
 
+function renderIssueReportsSection(issueReports) {
+  if (!issueReports || issueReports.length === 0) return '';
+
+  const reportCards = issueReports.map(r => {
+    const catBadges = (r.categories || []).map(c =>
+      `<span class="ir-cat-badge">${escapeHtml(c.replace(/_/g, ' '))}</span>`
+    ).join(' ');
+
+    const autoTag = r.autoDetected
+      ? '<span class="ir-auto-tag">auto-detected</span>'
+      : '';
+
+    const desc = r.description
+      ? `<div class="ir-desc">${escapeHtml(r.description)}</div>`
+      : '<div class="ir-desc ir-desc-empty">No description provided</div>';
+
+    const di = r.deviceInfo || {};
+    const deviceStr = [di.browser, di.os].filter(Boolean).join(' · ') || '—';
+
+    return `<div class="ir-report-card">
+      <div class="ir-report-header">
+        <span class="ir-flag-icon">⚑</span>
+        <span class="ir-report-time">${formatTs(r.createdAt)}</span>
+        ${autoTag}
+        <span class="ir-report-session" title="${escapeHtml(r.sessionId)}">${escapeHtml(String(r.sessionId).slice(0, 8))}…</span>
+        <span class="ir-report-device">${escapeHtml(deviceStr)}</span>
+      </div>
+      ${catBadges ? `<div class="ir-cats">${catBadges}</div>` : ''}
+      ${desc}
+    </div>`;
+  }).join('\n');
+
+  return `<div class="ir-section">
+  <div class="ir-section-title">⚑ ${issueReports.length} Issue Report${issueReports.length !== 1 ? 's' : ''}</div>
+  ${reportCards}
+</div>`;
+}
+
 function renderConnectionDots(sessionStates) {
   if (!sessionStates || sessionStates.length === 0) return '';
   return sessionStates.slice(0, 2).map(s => {
@@ -315,14 +353,15 @@ function renderGamesNav(recentGames, currentGameId) {
 ${legend}`;
 }
 
-function renderDiagnosticsHTML(result, context, recentGames = [], game = null) {
+function renderDiagnosticsHTML(result, context, recentGames = [], game = null, issueReports = []) {
   const { events = [], count = 0 } = result;
   const ctxLabel = context || `Game ${result.gameId}`;
   const firstTs = events.length ? events[0].timestamp : null;
   const lastTs  = events.length ? events[events.length - 1].timestamp : null;
   const timeRange = firstTs ? `${formatTs(firstTs)} → ${formatTs(lastTs)}` : 'No events';
   const sessions = groupBySession(events);
-  const rawJson = escapeHtml(JSON.stringify(result, null, 2));
+  const resultWithIssues = { ...result, issueReports };
+  const rawJson = escapeHtml(JSON.stringify(resultWithIssues, null, 2));
   const roomCodes = [...new Set(events.map(e => e.roomCode).filter(Boolean))].join(', ') || '—';
 
   return `<!DOCTYPE html>
@@ -435,6 +474,21 @@ function renderDiagnosticsHTML(result, context, recentGames = [], game = null) {
 
   /* Empty */
   .empty { color: #475569; padding: 48px; text-align: center; }
+
+  /* Issue Reports */
+  .ir-section { margin: 12px 24px; }
+  .ir-section-title { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: #f87171; margin-bottom: 10px; }
+  .ir-report-card { background: #1e293b; border: 1px solid #7f1d1d; border-left: 3px solid #ef4444; border-radius: 10px; padding: 12px 16px; margin-bottom: 8px; }
+  .ir-report-header { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 6px; }
+  .ir-flag-icon { color: #f87171; font-size: 14px; }
+  .ir-report-time { color: #94a3b8; font-size: 11px; white-space: nowrap; }
+  .ir-auto-tag { background: #7f1d1d; color: #fca5a5; font-size: 10px; padding: 1px 8px; border-radius: 999px; font-weight: 600; }
+  .ir-report-session { color: #475569; font-size: 11px; margin-left: auto; }
+  .ir-report-device { color: #475569; font-size: 11px; }
+  .ir-cats { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 6px; }
+  .ir-cat-badge { background: #451a03; border: 1px solid #92400e; color: #fbbf24; padding: 2px 10px; border-radius: 999px; font-size: 11px; font-weight: 600; }
+  .ir-desc { color: #e2e8f0; font-size: 12px; line-height: 1.5; padding: 6px 0; }
+  .ir-desc-empty { color: #475569; font-style: italic; }
 </style>
 </head>
 <body>
@@ -456,6 +510,7 @@ function renderDiagnosticsHTML(result, context, recentGames = [], game = null) {
   <div class="stat"><span class="stat-label">Events</span><span class="stat-value">${count}</span></div>
   <div class="stat"><span class="stat-label">Sessions</span><span class="stat-value">${sessions.length}</span></div>
   <div class="stat"><span class="stat-label">Time range</span><span class="stat-value" style="font-size:12px">${timeRange}</span></div>
+  ${issueReports.length > 0 ? `<div class="stat"><span class="stat-label">Issues</span><span class="stat-value" style="color:#f87171">⚑ ${issueReports.length} flagged</span></div>` : ''}
 </div>
 
 ${renderGamesNav(recentGames, result.gameId)}
@@ -463,6 +518,8 @@ ${renderGamesNav(recentGames, result.gameId)}
 ${events.length > 0 ? `<div class="filter-bar"><span class="filter-label">Show</span>${categoryFilterBar(events)}</div>` : ''}
 
 ${renderMovesSection(game)}
+
+${renderIssueReportsSection(issueReports)}
 
 <div class="sessions">
   ${events.length === 0
@@ -477,7 +534,7 @@ ${renderMovesSection(game)}
 </div>
 
 <script>
-var _json = ${JSON.stringify(JSON.stringify(result))};
+var _json = ${JSON.stringify(JSON.stringify(resultWithIssues))};
 var _gameId = ${result.gameId ? result.gameId : 'null'};
 function copyApiLink() {
   var url = location.origin + '/api/chess/diagnostics/game/' + _gameId;

--- a/routes/diagnostics.js
+++ b/routes/diagnostics.js
@@ -9,6 +9,7 @@ const {
   getDiagnosticsRecentGames,
   getGameSessionStates,
   getGame,
+  getIssueReportsByGame,
 } = require('../db');
 const { renderDiagnosticsHTML } = require('./diagnostics-html');
 
@@ -72,7 +73,8 @@ router.get('/diagnostics', (req, res) => {
         : g
     );
     const game = result.gameId ? getGame(result.gameId) : null;
-    return res.send(renderDiagnosticsHTML(result, `Game ${result.gameId}`, recentGamesWithStates, game));
+    const issueReports = result.gameId ? getIssueReportsByGame(result.gameId) : [];
+    return res.send(renderDiagnosticsHTML(result, `Game ${result.gameId}`, recentGamesWithStates, game, issueReports));
   } catch (e) {
     console.error('GET /diagnostics error:', e.message);
     res.status(500).json({ error: e.message });
@@ -91,7 +93,8 @@ router.get('/diagnostics/game/:id', (req, res) => {
       limit: Math.min(parseInt(limit, 10) || 500, 1000),
       offset: parseInt(offset, 10) || 0,
     });
-    const result = { gameId, events, count: events.length };
+    const issueReports = getIssueReportsByGame(gameId);
+    const result = { gameId, events, count: events.length, issueReports };
 
     res.json(result);
   } catch (e) {
@@ -149,7 +152,8 @@ router.get('/diagnostics/recent', (req, res) => {
     });
     if (result.gameId === null) return res.status(404).json({ error: 'No game diagnostics found' });
 
-    res.json(result);
+    const issueReports = result.gameId ? getIssueReportsByGame(result.gameId) : [];
+    res.json({ ...result, issueReports });
   } catch (e) {
     console.error('GET /diagnostics/recent error:', e.message);
     res.status(500).json({ error: e.message });

--- a/routes/issues.js
+++ b/routes/issues.js
@@ -1,0 +1,85 @@
+const express = require('express');
+const router = express.Router();
+const {
+  createIssueReport,
+  updateIssueReport,
+  getIssueReportByGame,
+  getIssueReport,
+} = require('../db');
+
+// POST /api/chess/issues — create a new issue report (flag a game)
+router.post('/issues', (req, res) => {
+  try {
+    const { gameId, sessionId, autoDetected, deviceInfo } = req.body;
+
+    if (!sessionId) {
+      return res.status(400).json({ error: 'sessionId is required' });
+    }
+
+    const report = createIssueReport(
+      gameId || null,
+      sessionId,
+      !!autoDetected,
+      deviceInfo || {}
+    );
+
+    res.status(201).json(report);
+  } catch (e) {
+    console.error('POST /issues error:', e.message);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// PATCH /api/chess/issues/:id — update categories and/or description
+router.patch('/issues/:id', (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (isNaN(id)) return res.status(400).json({ error: 'Invalid report ID' });
+
+    const existing = getIssueReport(id);
+    if (!existing) return res.status(404).json({ error: 'Report not found' });
+
+    const { categories, description } = req.body;
+    const updates = {};
+
+    if (categories !== undefined) {
+      if (!Array.isArray(categories)) {
+        return res.status(400).json({ error: 'categories must be an array' });
+      }
+      updates.categories = categories;
+    }
+
+    if (description !== undefined) {
+      if (typeof description !== 'string') {
+        return res.status(400).json({ error: 'description must be a string' });
+      }
+      updates.description = description;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ error: 'No valid fields to update' });
+    }
+
+    updateIssueReport(id, updates);
+    res.status(200).json({ success: true });
+  } catch (e) {
+    console.error('PATCH /issues/:id error:', e.message);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// GET /api/chess/issues/game/:id — check if a game has been flagged
+router.get('/issues/game/:id', (req, res) => {
+  try {
+    const gameId = parseInt(req.params.id, 10);
+    if (isNaN(gameId)) return res.status(400).json({ error: 'Invalid game ID' });
+
+    const report = getIssueReportByGame(gameId);
+    res.json({ report });
+  } catch (e) {
+    console.error('GET /issues/game/:id error:', e.message);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary

- Adds `issue_reports` table to SQLite DB with backwards-compatible migration
- New `routes/issues.js`: POST, PATCH, GET endpoints for issue reports
- Integrates issue reports into diagnostics HTML dashboard and JSON API
- Multiple reports per game supported

## Files Changed

- `db.js` — `issue_reports` table, 5 helper functions
- `routes/issues.js` — NEW: POST /api/chess/issues, PATCH /api/chess/issues/:id, GET /api/chess/issues/game/:id
- `routes/diagnostics.js` — imports `getIssueReportsByGame`, passes to HTML/JSON responses
- `routes/diagnostics-html.js` — `renderIssueReportsSection`, CSS, flagged stat in summary bar
- `index.js` — mounts issues router

## Test plan

- [ ] POST /api/chess/issues creates report, returns 201 with id
- [ ] PATCH /api/chess/issues/:id updates categories and description
- [ ] GET /api/chess/diagnostics?gameId=N shows issue reports section
- [ ] GET /api/chess/diagnostics/game/:id JSON includes `issueReports` array
- [ ] GET /api/chess/diagnostics/recent JSON includes `issueReports` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)