### PR TITLE
fix: include videoEnabled in rematch_start payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.20.0000",
+  "version": "1.20.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -362,6 +362,7 @@ function handleRematchResponse(sessionId, accept) {
     timeControl: room.timeControl,
     chess960: room.chess960,
     dbGameId: room.dbGameId,
+    videoEnabled: room.videoEnabled,
   };
 
   send(room.white.ws, 'rematch_start', { ...startPayload, color: 'w', opponentName: room.black.name });


### PR DESCRIPTION
## Summary

- Add `videoEnabled: room.videoEnabled` to the `rematch_start` payload so clients know whether to re-establish the video board and WebRTC call on rematch

## Test plan
- [ ] Start a boardface multiplayer game, play to end, rematch
- [ ] Verify video reconnects on the rematch game