### PR TITLE
fix: dynamic reconnect grace period based on clock time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.25.0000",
+  "version": "1.25.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -520,6 +520,14 @@ function handleRematchResponse(sessionId, accept) {
   send(room.black.ws, 'rematch_start', { ...startPayload, color: 'b', opponentName: room.white.name });
 }
 
+function getGracePeriod(room, side) {
+  if (room.clocks) {
+    const remaining = getCurrentClockTime(room, side);
+    return Math.max(remaining, 10_000);
+  }
+  return 10 * 60 * 1000;
+}
+
 function handleDisconnect(sessionId) {
   const roomId = sessionRooms.get(sessionId);
   if (!roomId) return;
@@ -566,9 +574,10 @@ function handleDisconnect(sessionId) {
   }
 
   // Notify opponent
+  const gracePeriod = getGracePeriod(room, side);
   const opponent = getPlayerBySide(room, side === 'w' ? 'b' : 'w');
   if (opponent && opponent.ws) {
-    send(opponent.ws, 'opponent_disconnected', { timeout: DISCONNECT_GRACE_PERIOD / 1000 });
+    send(opponent.ws, 'opponent_disconnected', { timeout: Math.ceil(gracePeriod / 1000) });
   }
 
   // Start grace period
@@ -580,7 +589,7 @@ function handleDisconnect(sessionId) {
         const result = side === 'w' ? '0-1' : '1-0';
         finishGame(room, result, 'abandoned');
       }
-    }, DISCONNECT_GRACE_PERIOD);
+    }, gracePeriod);
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces the hardcoded 60-second `DISCONNECT_GRACE_PERIOD` for in-game disconnects with a dynamic value via `getGracePeriod(room, side)`
- For timed games: grace period = disconnected player's remaining clock time (minimum 10 seconds). This is fair — the player can't gain time by disconnecting, and the opponent sees an accurate countdown
- For untimed games: grace period = 10 minutes (previously 60 seconds, which was too short for casual play)
- Lobby and waiting-room timeouts are unchanged
- Bumps version to 1.25.0001

## Test plan

- [ ] Start a timed game (e.g. 3+0), disconnect one player early — opponent countdown should show ~remaining clock seconds
- [ ] Start a timed game, run the clock down to ~15 seconds, disconnect — opponent sees ~15 second countdown
- [ ] Start an untimed game, disconnect — opponent sees ~600 second countdown
- [ ] Let grace period expire — abandoned game result assigned correctly