### PR TITLE
Allow setting_change during waiting status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chess-api",
-  "version": "1.20.0001",
+  "version": "1.25.0001",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-api",
-      "version": "1.20.0001",
+      "version": "1.25.0001",
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.25.0001",
+  "version": "1.25.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -166,10 +166,13 @@ function handleSettingChange(sessionId, field, value) {
   const roomId = sessionRooms.get(sessionId);
   if (!roomId) return;
   const room = rooms.get(roomId);
-  if (!room || room.status !== 'lobby') return;
+  if (!room || (room.status !== 'lobby' && room.status !== 'waiting')) return;
 
   const validFields = ['timeControl', 'chess960', 'colorSwap'];
   if (!validFields.includes(field)) return;
+
+  // colorSwap requires two players
+  if (field === 'colorSwap' && room.status === 'waiting') return;
 
   const side = getPlayerSide(room, sessionId);
   if (!side) return;
@@ -198,6 +201,17 @@ function handleSettingChange(sessionId, field, value) {
     const oldBlack = room.black;
     room.white = { ...oldBlack };
     room.black = { ...oldWhite };
+  }
+
+  // While waiting: just acknowledge the change back to the creator
+  if (room.status === 'waiting') {
+    const updatedSettings = {
+      timeControl: room.timeControl,
+      chess960: room.chess960,
+      videoEnabled: room.videoEnabled,
+    };
+    send(room.white.ws, 'setting_changed', { field, settings: updatedSettings, ready: { w: false, b: false }, color: 'w', changedBy: 'w' });
+    return;
   }
 
   // Reset ready states on any change


### PR DESCRIPTION
handleSettingChange now accepts timeControl and chess960 changes when room.status === 'waiting'. Color swap excluded during waiting. Settings persist to lobby_joined when opponent joins.