### PR TITLE
fix: handle camMode setting change in lobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.25.0001",
+  "version": "1.25.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -79,7 +79,7 @@ function createRoom(ws, sessionId, name, timeControl, camMode, chess960) {
 
   const is960 = !!chess960;
   const startFen = is960 ? generateChess960FEN() : undefined;
-  const effectiveCamMode = ['none', 'king-cam', 'board-face'].includes(camMode) ? camMode : 'none';
+  const effectiveCamMode = ['none', 'king-cam', 'board-face', 'split-cam'].includes(camMode) ? camMode : 'none';
 
   const room = {
     id: roomId,
@@ -151,7 +151,7 @@ function joinRoom(ws, sessionId, name, roomId) {
 
   const lobbyPayload = {
     roomId: room.id,
-    settings: { timeControl: room.timeControl, chess960: room.chess960, videoEnabled: room.videoEnabled },
+    settings: { timeControl: room.timeControl, chess960: room.chess960, videoEnabled: room.videoEnabled, camMode: room.camMode },
     white: { name: room.white.name, ready: false },
     black: { name: room.black.name, ready: false },
   };
@@ -168,7 +168,7 @@ function handleSettingChange(sessionId, field, value) {
   const room = rooms.get(roomId);
   if (!room || room.status !== 'lobby') return;
 
-  const validFields = ['timeControl', 'chess960', 'colorSwap'];
+  const validFields = ['timeControl', 'chess960', 'colorSwap', 'camMode'];
   if (!validFields.includes(field)) return;
 
   const side = getPlayerSide(room, sessionId);
@@ -198,6 +198,12 @@ function handleSettingChange(sessionId, field, value) {
     const oldBlack = room.black;
     room.white = { ...oldBlack };
     room.black = { ...oldWhite };
+  } else if (field === 'camMode') {
+    const validCamModes = ['none', 'king-cam', 'board-face', 'split-cam'];
+    if (validCamModes.includes(value)) {
+      room.camMode = value;
+      room.videoEnabled = value !== 'none';
+    }
   }
 
   // Reset ready states on any change
@@ -207,6 +213,7 @@ function handleSettingChange(sessionId, field, value) {
     timeControl: room.timeControl,
     chess960: room.chess960,
     videoEnabled: room.videoEnabled,
+    camMode: room.camMode,
   };
 
   send(room.white.ws, 'setting_changed', { field, settings: updatedSettings, ready: { w: false, b: false }, color: 'w', changedBy: side });
@@ -291,7 +298,7 @@ function attemptLobbyReconnect(ws, sessionId, room) {
 
   const lobbyPayload = {
     roomId: room.id,
-    settings: { timeControl: room.timeControl, chess960: room.chess960, videoEnabled: room.videoEnabled },
+    settings: { timeControl: room.timeControl, chess960: room.chess960, videoEnabled: room.videoEnabled, camMode: room.camMode },
     white: { name: room.white.name, ready: room.ready.w },
     black: { name: room.black.name, ready: room.ready.b },
   };


### PR DESCRIPTION
## Summary

- Added `camMode` to valid lobby setting fields so cam changes are processed
- Store `room.camMode` and broadcast it to both players on change
- Added `split-cam` as a valid cam mode in createRoom
- Include `camMode` in `lobby_joined` settings payload so joining player gets the room's cam setting

## Changes

**`rooms.js`**
- `handleSettingChange`: added `'camMode'` to `validFields`, apply change to `room.camMode` and `room.videoEnabled`
- `updatedSettings`: added `camMode` field broadcast to both players
- `createRoom`: added `'split-cam'` to valid cam modes
- `lobby_joined` payloads: added `camMode` to settings (both initial join and reconnect)

## Test plan

- [ ] Create room with king-cam, join — both players receive `camMode: 'king-cam'` in lobby_joined
- [ ] Change cam in lobby — setting_changed broadcasts camMode to both players

🤖 Generated with [Claude Code](https://claude.com/claude-code)