### PR TITLE
fix: include game (moves) in diagnostics Copy JSON output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.25.0002",
+  "version": "1.25.0003",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -361,7 +361,7 @@ function renderDiagnosticsHTML(result, context, recentGames = [], game = null, i
   const lastTs  = events.length ? events[events.length - 1].timestamp : null;
   const timeRange = firstTs ? `${formatTs(firstTs)} → ${formatTs(lastTs)}` : 'No events';
   const sessions = groupBySession(events);
-  const resultWithIssues = { ...result, issueReports };
+  const resultWithIssues = { ...result, issueReports, game };
   const rawJson = escapeHtml(JSON.stringify(resultWithIssues, null, 2));
   const roomCodes = [...new Set(events.map(e => e.roomCode).filter(Boolean))].join(', ') || '—';
 


### PR DESCRIPTION
The Copy JSON button on the diagnostics page was missing the `game` object (which contains moves, player names, time control, etc.) from the copied JSON.

## Changes

- `routes/diagnostics-html.js`: Add `game` to the `resultWithIssues` object so the Copy JSON button now includes `issueReports` and `game.moves` in its output.

## Before / After

**Before:** copied JSON had `events`, `count`, `gameId`, `issueReports`
**After:** copied JSON additionally includes `game` (with `moves`, player info, time control, result)