### PR TITLE
White pills for games with issue reports

### DIFF
--- a/db.js
+++ b/db.js
@@ -753,7 +753,8 @@ function getDiagnosticsRecentGames({ limit = 20 } = {}) {
     `SELECT d.game_id, COUNT(d.id) as event_count,
             MIN(d.timestamp) as first_ts, MAX(d.timestamp) as last_ts,
             g.result, g.result_reason, g.end_time,
-            (SELECT COUNT(*) FROM moves m WHERE m.game_id = d.game_id) as move_count
+            (SELECT COUNT(*) FROM moves m WHERE m.game_id = d.game_id) as move_count,
+            (SELECT COUNT(*) FROM issue_reports ir WHERE ir.game_id = d.game_id) as issue_count
      FROM diagnostic_events d
      LEFT JOIN games g ON g.id = d.game_id
      WHERE d.game_id IS NOT NULL
@@ -767,6 +768,7 @@ function getDiagnosticsRecentGames({ limit = 20 } = {}) {
     resultReason: r.result_reason || null,
     endTime: r.end_time || null,
     moveCount: r.move_count || 0,
+    issueCount: r.issue_count || 0,
   }));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chess-api",
-  "version": "1.25.0001",
+  "version": "1.26.0000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-api",
-      "version": "1.25.0001",
+      "version": "1.26.0000",
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.26.0000",
+  "version": "1.26.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -9,6 +9,7 @@ const PILL_COLORS = {
   abandoned:         { border: '#eab308', bg: '#422006', activeBg: '#713f12', text: '#fbbf24' },
   connection_failed: { border: '#ef4444', bg: '#450a0a', activeBg: '#7f1d1d', text: '#f87171' },
   ongoing:           { border: '#3b82f6', bg: '#0c2340', activeBg: '#1d4ed8', text: '#60a5fa' },
+  has_issues:        { border: '#ffffff', bg: '#2d2d2d', activeBg: '#3d3d3d', text: '#ffffff' },
 };
 
 function computePillStatus(game) {
@@ -325,7 +326,7 @@ function renderGamesNav(recentGames, currentGameId) {
 
   const items = recentGames.map(g => {
     const isCurrent = g.gameId === currentGameId;
-    const status = computePillStatus(g);
+    const status = g.issueCount > 0 ? 'has_issues' : computePillStatus(g);
     const colors = PILL_COLORS[status];
     const label = `#${g.gameId} · ${g.eventCount} event${g.eventCount !== 1 ? 's' : ''} · ${formatTs(g.lastTs)}`;
 


### PR DESCRIPTION
## Summary
- Game pills in the diagnostics nav sidebar now render in white when a game has user-submitted issue reports
- Adds `issue_count` subquery to `getDiagnosticsRecentGames` in `db.js`
- Adds `has_issues` pill color entry in `diagnostics-html.js`
- `renderGamesNav` checks `g.issueCount > 0` and overrides pill status to `has_issues`

## Test plan
- [ ] Navigate to the diagnostics page for any game
- [ ] Verify games with issue reports appear as white pills in the sidebar
- [ ] Verify games without issue reports retain their normal colors (green/yellow/red/blue)