### PR TITLE
feat: add split-cam-h to valid cam mode whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.26.0000",
+  "version": "1.26.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -79,7 +79,7 @@ function createRoom(ws, sessionId, name, timeControl, camMode, chess960) {
 
   const is960 = !!chess960;
   const startFen = is960 ? generateChess960FEN() : undefined;
-  const effectiveCamMode = ['none', 'king-cam', 'board-face', 'split-cam'].includes(camMode) ? camMode : 'none';
+  const effectiveCamMode = ['none', 'king-cam', 'board-face', 'split-cam', 'split-cam-h'].includes(camMode) ? camMode : 'none';
 
   const room = {
     id: roomId,
@@ -202,7 +202,7 @@ function handleSettingChange(sessionId, field, value) {
     room.white = { ...oldBlack };
     room.black = { ...oldWhite };
   } else if (field === 'camMode') {
-    const validCamModes = ['none', 'king-cam', 'board-face', 'split-cam'];
+    const validCamModes = ['none', 'king-cam', 'board-face', 'split-cam', 'split-cam-h'];
     if (validCamModes.includes(value)) {
       room.camMode = value;
       room.videoEnabled = value !== 'none';


### PR DESCRIPTION
## Summary
- Added `split-cam-h` to the valid cam modes whitelist in both `createRoom` and `proposeSetting` handlers in `rooms.js`
- Without this, the server rejects `split-cam-h` proposals and broadcasts back the old mode, causing the lobby cam button to revert

## Files Changed
- `rooms.js` — added `'split-cam-h'` to both cam mode whitelists (lines 82 and 205)

## Test plan
- [ ] In the lobby with both players, switch cam to Top / Bottom — verify it stays and doesn't revert