### PR TITLE
fix: show lobby-only sessions on diagnostics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ REST API server for persistent chess game storage. Stores games and moves in a S
 
 ## Version
 
-**Current:** `1.27.0000`
+**Current:** `1.28.0000`
 
 The `/api/health` endpoint returns the server version. The client checks this on startup to verify compatibility.
 

--- a/db.js
+++ b/db.js
@@ -772,6 +772,46 @@ function getDiagnosticsRecentGames({ limit = 20 } = {}) {
   }));
 }
 
+function getDiagnosticsLobbyOnlyRooms({ limit = 5 } = {}) {
+  return db.prepare(
+    `SELECT de.room_code, COUNT(de.id) as event_count,
+            MIN(de.timestamp) as first_ts, MAX(de.timestamp) as last_ts,
+            (SELECT COUNT(*) FROM issue_reports ir
+             WHERE ir.session_id IN (
+               SELECT DISTINCT session_id FROM diagnostic_events WHERE room_code = de.room_code
+             )) as issue_count
+     FROM diagnostic_events de
+     WHERE de.game_id IS NULL AND de.room_code IS NOT NULL
+     GROUP BY de.room_code
+     ORDER BY MAX(de.timestamp) DESC
+     LIMIT ?`
+  ).all(limit).map(r => ({
+    roomCode: r.room_code,
+    gameId: null,
+    eventCount: r.event_count,
+    firstTs: r.first_ts,
+    lastTs: r.last_ts,
+    result: null,
+    issueCount: r.issue_count || 0,
+  }));
+}
+
+function getIssueReportsByRoomCode(roomCode) {
+  const rows = db.prepare(
+    `SELECT ir.* FROM issue_reports ir
+     WHERE ir.session_id IN (
+       SELECT DISTINCT session_id FROM diagnostic_events WHERE room_code = ?
+     )
+     ORDER BY ir.created_at ASC`
+  ).all(roomCode);
+  return rows.map(r => ({
+    ...r,
+    categories: JSON.parse(r.categories || '[]'),
+    deviceInfo: JSON.parse(r.device_info || '{}'),
+    autoDetected: !!r.auto_detected,
+  }));
+}
+
 function getGameSessionStates(gameId) {
   // Get top-2 sessions by most recent activity for the game
   const sessions = db.prepare(
@@ -938,5 +978,7 @@ module.exports = {
   updateIssueReport,
   getIssueReportByGame,
   getIssueReportsByGame,
+  getIssueReportsByRoomCode,
+  getDiagnosticsLobbyOnlyRooms,
   getIssueReport,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.27.0000",
+  "version": "1.27.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.27.0001",
+  "version": "1.28.0000",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -321,23 +321,31 @@ function renderConnectionDots(sessionStates) {
   }).join('');
 }
 
-function renderGamesNav(recentGames, currentGameId) {
+function renderGamesNav(recentGames, currentGameId, currentRoomCode) {
   if (!recentGames || recentGames.length === 0) return '';
 
   const items = recentGames.map(g => {
-    const isCurrent = g.gameId === currentGameId;
+    const isRoom = !g.gameId && g.roomCode;
+    const isCurrent = isRoom
+      ? g.roomCode === currentRoomCode
+      : g.gameId === currentGameId;
     const status = g.issueCount > 0 ? 'has_issues' : computePillStatus(g);
     const colors = PILL_COLORS[status];
-    const label = `#${g.gameId} · ${g.eventCount} event${g.eventCount !== 1 ? 's' : ''} · ${formatTs(g.lastTs)}`;
+    const label = isRoom
+      ? `Room ${g.roomCode} · ${g.eventCount} event${g.eventCount !== 1 ? 's' : ''} · ${formatTs(g.lastTs)}`
+      : `#${g.gameId} · ${g.eventCount} event${g.eventCount !== 1 ? 's' : ''} · ${formatTs(g.lastTs)}`;
 
     const dots = status === 'ongoing' ? renderConnectionDots(g.sessionStates) : '';
     const pillBg = isCurrent ? colors.activeBg : colors.bg;
     const inlineStyle = `background:${pillBg};border-color:${colors.border};color:${colors.text};`;
+    const href = isRoom
+      ? `/api/chess/diagnostics?roomCode=${encodeURIComponent(g.roomCode)}`
+      : `/api/chess/diagnostics?gameId=${g.gameId}`;
 
     if (isCurrent) {
       return `<span class="game-nav-item game-nav-current" style="${inlineStyle}" title="Currently viewing">${dots}${escapeHtml(label)}</span>`;
     }
-    return `<a class="game-nav-item" href="/api/chess/diagnostics?gameId=${g.gameId}" style="${inlineStyle}">${dots}${escapeHtml(label)}</a>`;
+    return `<a class="game-nav-item" href="${href}" style="${inlineStyle}">${dots}${escapeHtml(label)}</a>`;
   }).join('');
 
   const legend = `<div class="pill-legend">
@@ -517,7 +525,7 @@ function renderDiagnosticsHTML(result, context, recentGames = [], game = null, i
   ${issueReports.length > 0 ? `<div class="stat"><span class="stat-label">Issues</span><span class="stat-value" style="color:#f87171">⚑ ${issueReports.length} flagged</span></div>` : ''}
 </div>
 
-${renderGamesNav(recentGames, result.gameId)}
+${renderGamesNav(recentGames, result.gameId, result.roomCode)}
 
 ${events.length > 0 ? `<div class="filter-bar"><span class="filter-label">Show</span>${categoryFilterBar(events)}</div>` : ''}
 

--- a/routes/diagnostics.js
+++ b/routes/diagnostics.js
@@ -7,9 +7,11 @@ const {
   getDiagnosticsBySession,
   getDiagnosticsRecent,
   getDiagnosticsRecentGames,
+  getDiagnosticsLobbyOnlyRooms,
   getGameSessionStates,
   getGame,
   getIssueReportsByGame,
+  getIssueReportsByRoomCode,
 } = require('../db');
 const { renderDiagnosticsHTML } = require('./diagnostics-html');
 
@@ -45,10 +47,10 @@ router.post('/diagnostics', (req, res) => {
   }
 });
 
-// GET /api/chess/diagnostics — HTML dashboard (most recent game, or ?gameId=N for a specific game)
+// GET /api/chess/diagnostics — HTML dashboard (most recent game, ?gameId=N, or ?roomCode=X)
 router.get('/diagnostics', (req, res) => {
   try {
-    const { category, limit = 500, offset = 0, gameId: gameIdParam } = req.query;
+    const { category, limit = 500, offset = 0, gameId: gameIdParam, roomCode: roomCodeParam } = req.query;
     const queryOpts = {
       category: category || null,
       limit: Math.min(parseInt(limit, 10) || 500, 1000),
@@ -61,6 +63,10 @@ router.get('/diagnostics', (req, res) => {
       if (isNaN(gameId)) return res.status(400).send('<p>Invalid game ID.</p>');
       const events = getDiagnosticsByGame(gameId, queryOpts);
       result = { gameId, events, count: events.length };
+    } else if (roomCodeParam) {
+      const roomCode = roomCodeParam.toUpperCase();
+      const events = getDiagnosticsByRoom(roomCode, queryOpts);
+      result = { roomCode, gameId: null, events, count: events.length };
     } else {
       result = getDiagnosticsRecent(queryOpts);
       if (result.gameId === null) return res.status(404).send('<p>No game diagnostics found.</p>');
@@ -72,9 +78,15 @@ router.get('/diagnostics', (req, res) => {
         ? { ...g, sessionStates: getGameSessionStates(g.gameId) }
         : g
     );
+    const lobbyRooms = getDiagnosticsLobbyOnlyRooms();
+    const allNavEntries = [...recentGamesWithStates, ...lobbyRooms];
+
     const game = result.gameId ? getGame(result.gameId) : null;
-    const issueReports = result.gameId ? getIssueReportsByGame(result.gameId) : [];
-    return res.send(renderDiagnosticsHTML(result, `Game ${result.gameId}`, recentGamesWithStates, game, issueReports));
+    const issueReports = result.gameId
+      ? getIssueReportsByGame(result.gameId)
+      : (result.roomCode ? getIssueReportsByRoomCode(result.roomCode) : []);
+    const contextLabel = result.gameId ? `Game ${result.gameId}` : (result.roomCode ? `Room ${result.roomCode}` : 'Unknown');
+    return res.send(renderDiagnosticsHTML(result, contextLabel, allNavEntries, game, issueReports));
   } catch (e) {
     console.error('GET /diagnostics error:', e.message);
     res.status(500).json({ error: e.message });


### PR DESCRIPTION
## Summary

- Add `getDiagnosticsLobbyOnlyRooms()` — queries recent room sessions with no game ID, including issue counts
- Add `getIssueReportsByRoomCode()` — finds issue reports for a room via session join on `diagnostic_events`
- Update `GET /diagnostics` to accept `?roomCode=` param and merge lobby rooms into the nav
- Update `renderGamesNav` to link room-only entries to `?roomCode=` with "Room XXXX" labels

Fixes: issue reports submitted in the lobby (before a game starts) were invisible on the dashboard because the nav only showed game-based sessions.

## Test plan
- [ ] Visit `/api/chess/diagnostics` after a lobby session — Room entry appears in left nav
- [ ] Click Room entry — shows lifecycle events and any issue reports for that room
- [ ] Existing `?gameId=` routes unchanged, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)