### PR TITLE
Add Cloudflare TURN as primary ICE server with Metered fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chess-api",
-  "version": "1.26.0000",
+  "version": "1.28.0001",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-api",
-      "version": "1.26.0000",
+      "version": "1.28.0001",
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.28.0000",
+  "version": "1.28.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/ice-servers.js
+++ b/routes/ice-servers.js
@@ -4,9 +4,16 @@
  * Returns STUN servers always. Returns TURN credentials as well when
  * configured via environment variables.
  *
- * Two TURN credential modes are supported:
+ * Three TURN credential modes are supported:
  *
- * 1. Static credentials (Metered.ca / Open Relay):
+ * 1. Cloudflare TURN (primary, with Metered.ca fallback):
+ *    CLOUDFLARE_TURN_KEY_ID, CLOUDFLARE_TURN_API_TOKEN
+ *
+ *    Makes a server-side fetch to the Cloudflare TURN credentials API and
+ *    returns those ICE servers combined with any configured Metered servers.
+ *    If the Cloudflare API fails, falls back to Metered-only.
+ *
+ * 2. Static credentials (Metered.ca / Open Relay):
  *    TURN_URLS, TURN_USERNAME, TURN_PASSWORD
  *
  *    TURN_URLS is a comma-separated list of complete TURN URLs (including scheme
@@ -17,11 +24,12 @@
  *
  *    TURN_URL (singular) is a legacy fallback — expands to turn:<URL> and turns:<URL>.
  *
- * 2. HMAC-SHA1 time-limited credentials (self-hosted coturn):
+ * 3. HMAC-SHA1 time-limited credentials (self-hosted coturn):
  *    TURN_URL, TURN_SECRET
  *    Generates 24-hour tokens using the coturn REST API format.
  *
- * Static mode takes precedence if both are configured.
+ * Static mode (2) takes precedence over HMAC (3) if both are configured.
+ * Cloudflare mode (1) takes precedence over all others if configured.
  */
 
 const express = require('express');
@@ -33,27 +41,51 @@ const STUN_SERVERS = [
   { urls: 'stun:stun1.l.google.com:19302' },
 ];
 
-// GET /api/chess/ice-servers — returns ICE server config for WebRTC
-router.get('/ice-servers', (req, res) => {
+let cloudflareFetchCount = 0;
+
+// Fetch ICE servers from Cloudflare TURN credentials API.
+// Returns an array of ICE server objects, or null on failure.
+async function fetchCloudflareIceServers(keyId, apiToken) {
+  const url = `https://rtc.live.cloudflare.com/v1/turn/keys/${keyId}/credentials/generate-ice-servers`;
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ttl: 86400 }),
+    });
+    if (!response.ok) {
+      console.error(`[ice-servers] Cloudflare TURN API error: ${response.status} ${response.statusText}`);
+      return null;
+    }
+    const data = await response.json();
+    cloudflareFetchCount++;
+    console.log(`[ice-servers] Cloudflare credentials generated (total this session: ${cloudflareFetchCount})`);
+    return data.iceServers || null;
+  } catch (err) {
+    console.error('[ice-servers] Cloudflare TURN fetch failed:', err.message);
+    return null;
+  }
+}
+
+// Build Metered/static TURN servers from env vars. Returns an array (may be empty).
+function buildMeteredServers() {
   const turnUrls = process.env.TURN_URLS;
   const turnUrl = process.env.TURN_URL;
   const turnUsername = process.env.TURN_USERNAME;
   const turnPassword = process.env.TURN_PASSWORD;
   const turnSecret = process.env.TURN_SECRET;
 
-  const hasTurnConfig = turnUrls || turnUrl;
-  if (!hasTurnConfig) {
-    return res.json(STUN_SERVERS);
-  }
+  if (!turnUrls && !turnUrl) return [];
 
   let username, credential;
 
   if (turnUsername && turnPassword) {
-    // Static credentials (Metered.ca, Open Relay, etc.)
     username = turnUsername;
     credential = turnPassword;
   } else if (turnSecret) {
-    // HMAC-SHA1 time-limited credentials (coturn REST API format, expire in 24h)
     const expiry = Math.floor(Date.now() / 1000) + 86400;
     username = String(expiry);
     credential = crypto
@@ -61,12 +93,9 @@ router.get('/ice-servers', (req, res) => {
       .update(username)
       .digest('base64');
   } else {
-    return res.json(STUN_SERVERS);
+    return [];
   }
 
-  // Build the list of TURN URLs.
-  // TURN_URLS: comma-separated complete URLs (recommended, e.g. from Metered dashboard).
-  // TURN_URL: legacy single base URL — expands to turn:<URL> and turns:<URL>.
   let urls;
   if (turnUrls) {
     urls = turnUrls.split(',').map(u => u.trim()).filter(Boolean);
@@ -74,12 +103,37 @@ router.get('/ice-servers', (req, res) => {
     urls = [`turn:${turnUrl}`, `turns:${turnUrl}`];
   }
 
-  const servers = [
-    ...STUN_SERVERS,
-    { urls, username, credential },
-  ];
+  return [{ urls, username, credential }];
+}
 
-  res.json(servers);
+// GET /api/chess/ice-servers — returns ICE server config for WebRTC
+router.get('/ice-servers', async (req, res) => {
+  const cfKeyId = process.env.CLOUDFLARE_TURN_KEY_ID;
+  const cfToken = process.env.CLOUDFLARE_TURN_API_TOKEN;
+
+  if (cfKeyId && cfToken) {
+    const cfServers = await fetchCloudflareIceServers(cfKeyId, cfToken);
+    const meteredServers = buildMeteredServers();
+
+    if (cfServers) {
+      // Cloudflare primary + Metered fallback (WebRTC tries all in parallel)
+      return res.json([...STUN_SERVERS, ...cfServers, ...meteredServers]);
+    }
+
+    // Cloudflare failed — fall back to Metered only
+    console.warn('[ice-servers] Falling back to Metered-only due to Cloudflare API failure');
+    if (meteredServers.length > 0) {
+      return res.json([...STUN_SERVERS, ...meteredServers]);
+    }
+    return res.json(STUN_SERVERS);
+  }
+
+  // No Cloudflare config — use Metered/static/HMAC mode
+  const meteredServers = buildMeteredServers();
+  if (meteredServers.length === 0) {
+    return res.json(STUN_SERVERS);
+  }
+  return res.json([...STUN_SERVERS, ...meteredServers]);
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary

- Adds Cloudflare TURN as the primary TURN provider via server-side credential fetch (Key ID + API Token env vars)
- Returns Cloudflare ICE servers combined with existing Metered.ca servers so WebRTC tries both in parallel
- Falls back to Metered-only if the Cloudflare API fails (network error or bad response)
- Extracts existing Metered/coturn logic into `buildMeteredServers()` helper — no behaviour change
- Logs a session counter each time Cloudflare credentials are generated

## New env vars required on server

- `CLOUDFLARE_TURN_KEY_ID` — Cloudflare Dashboard → Calls → TURN
- `CLOUDFLARE_TURN_API_TOKEN` — Cloudflare Dashboard → Calls → TURN

Both already set in production PM2.

## Test plan

- [ ] Deploy to production and hit `GET /api/chess/ice-servers`
- [ ] Confirm response includes both Cloudflare and Metered ICE server entries
- [ ] Check PM2 logs for `[ice-servers] Cloudflare credentials generated` message
- [ ] Verify WebRTC connections work in the chess game (multiplayer)