### PR TITLE
Include TURN provider in ICE servers response and diagnostics dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.29.0000",
+  "version": "1.29.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.29.0001",
+  "version": "1.29.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.29.0002",
+  "version": "1.30.0000",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -112,6 +112,7 @@ function computeWebRtcSummary(events) {
 
   const summary = {
     hasTurn: false,
+    turnProvider: null,
     serverCount: 0,
     candidates: { host: 0, srflx: 0, relay: 0, prflx: 0, unknown: 0 },
     iceState: null,
@@ -124,6 +125,7 @@ function computeWebRtcSummary(events) {
     const d = e.data || {};
     if (e.eventType === 'ice_servers_config') {
       summary.hasTurn = !!d.hasTurn;
+      summary.turnProvider = d.turnProvider || null;
       summary.serverCount = d.count || 0;
     } else if (e.eventType === 'ice_candidate_local') {
       const t = d.type || 'unknown';
@@ -150,11 +152,12 @@ function renderWebRtcSummary(summary) {
   const iceOk = summary.iceState === 'connected' || summary.iceState === 'completed';
   const connOk = summary.connectionState === 'connected';
 
+  const providerSuffix = summary.turnProvider ? ` [${escapeHtml(summary.turnProvider)}]` : '';
   const turnLabel = summary.hasTurn
     ? (turnOk
-        ? `<span class="wrtc-ok">TURN ✓ (${relayCount} relay)</span>`
-        : `<span class="wrtc-warn">TURN ⚠ (0 relay)</span>`)
-    : `<span class="wrtc-off">TURN off</span>`;
+        ? `<span class="wrtc-ok">TURN${providerSuffix} ✓ (${relayCount} relay)</span>`
+        : `<span class="wrtc-warn">TURN${providerSuffix} ⚠ (0 relay)</span>`)
+    : `<span class="wrtc-off">TURN off${providerSuffix}</span>`;
 
   const iceLabel = summary.iceState
     ? (iceOk

--- a/routes/ice-servers.js
+++ b/routes/ice-servers.js
@@ -106,6 +106,16 @@ function buildMeteredServers() {
   return [{ urls, username, credential }];
 }
 
+// Determine the TURN credential mode label for buildMeteredServers() output.
+// Returns 'metered' for static credentials, 'hmac' for HMAC/coturn, or null.
+function meteredProviderLabel() {
+  const { TURN_URLS, TURN_URL, TURN_USERNAME, TURN_PASSWORD, TURN_SECRET } = process.env;
+  if (!TURN_URLS && !TURN_URL) return null;
+  if (TURN_USERNAME && TURN_PASSWORD) return 'metered';
+  if (TURN_SECRET) return 'hmac';
+  return null;
+}
+
 // GET /api/chess/ice-servers — returns ICE server config for WebRTC
 router.get('/ice-servers', async (req, res) => {
   const cfKeyId = process.env.CLOUDFLARE_TURN_KEY_ID;
@@ -114,26 +124,36 @@ router.get('/ice-servers', async (req, res) => {
   if (cfKeyId && cfToken) {
     const cfServers = await fetchCloudflareIceServers(cfKeyId, cfToken);
     const meteredServers = buildMeteredServers();
+    const hasMetered = meteredServers.length > 0;
 
     if (cfServers) {
-      // Cloudflare primary + Metered fallback (WebRTC tries all in parallel)
-      return res.json([...STUN_SERVERS, ...cfServers, ...meteredServers]);
+      const turnProvider = hasMetered ? 'cloudflare+metered' : 'cloudflare';
+      return res.json({
+        iceServers: [...STUN_SERVERS, ...cfServers, ...meteredServers],
+        turnProvider,
+      });
     }
 
     // Cloudflare failed — fall back to Metered only
     console.warn('[ice-servers] Falling back to Metered-only due to Cloudflare API failure');
-    if (meteredServers.length > 0) {
-      return res.json([...STUN_SERVERS, ...meteredServers]);
+    if (hasMetered) {
+      return res.json({
+        iceServers: [...STUN_SERVERS, ...meteredServers],
+        turnProvider: meteredProviderLabel() || 'metered',
+      });
     }
-    return res.json(STUN_SERVERS);
+    return res.json({ iceServers: STUN_SERVERS, turnProvider: 'stun-only' });
   }
 
   // No Cloudflare config — use Metered/static/HMAC mode
   const meteredServers = buildMeteredServers();
   if (meteredServers.length === 0) {
-    return res.json(STUN_SERVERS);
+    return res.json({ iceServers: STUN_SERVERS, turnProvider: 'stun-only' });
   }
-  return res.json([...STUN_SERVERS, ...meteredServers]);
+  return res.json({
+    iceServers: [...STUN_SERVERS, ...meteredServers],
+    turnProvider: meteredProviderLabel() || 'metered',
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- `/api/chess/ice-servers` now returns `{ iceServers: [...], turnProvider }` instead of a flat array
- `turnProvider` values: `cloudflare`, `cloudflare+metered`, `metered`, `hmac`, `stun-only`
- Diagnostics HTML dashboard shows the provider in the TURN status label (e.g. `TURN off [stun-only]`)

## Files changed
- `routes/ice-servers.js` — response format, added `meteredProviderLabel()` helper
- `routes/diagnostics-html.js` — extract and display `turnProvider` in WebRTC summary

## Test plan
- [ ] `GET /api/chess/ice-servers` returns `{ iceServers, turnProvider }` object
- [ ] Without TURN env vars: `turnProvider: "stun-only"`
- [ ] With Cloudflare env vars: `turnProvider: "cloudflare"` or `"cloudflare+metered"`
- [ ] Diagnostics dashboard shows provider label in TURN status

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-TURN-Server-Diagnostics