### PR TITLE
Fix: scope issue reports to room_code

### DIFF
--- a/db.js
+++ b/db.js
@@ -217,6 +217,13 @@ function initDb() {
     CREATE INDEX IF NOT EXISTS idx_issue_reports_created_at ON issue_reports(created_at);
   `);
 
+  // Migration: add room_code column if not present
+  const irCols = db.prepare("PRAGMA table_info(issue_reports)").all().map(c => c.name);
+  if (!irCols.includes('room_code')) {
+    db.exec(`ALTER TABLE issue_reports ADD COLUMN room_code TEXT`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_issue_reports_room_code ON issue_reports(room_code)`);
+  }
+
   return db;
 }
 
@@ -777,9 +784,7 @@ function getDiagnosticsLobbyOnlyRooms({ limit = 5 } = {}) {
     `SELECT de.room_code, COUNT(de.id) as event_count,
             MIN(de.timestamp) as first_ts, MAX(de.timestamp) as last_ts,
             (SELECT COUNT(*) FROM issue_reports ir
-             WHERE ir.session_id IN (
-               SELECT DISTINCT session_id FROM diagnostic_events WHERE room_code = de.room_code
-             )) as issue_count
+             WHERE ir.room_code = de.room_code) as issue_count
      FROM diagnostic_events de
      WHERE de.game_id IS NULL AND de.room_code IS NOT NULL
      GROUP BY de.room_code
@@ -799,9 +804,7 @@ function getDiagnosticsLobbyOnlyRooms({ limit = 5 } = {}) {
 function getIssueReportsByRoomCode(roomCode) {
   const rows = db.prepare(
     `SELECT ir.* FROM issue_reports ir
-     WHERE ir.session_id IN (
-       SELECT DISTINCT session_id FROM diagnostic_events WHERE room_code = ?
-     )
+     WHERE ir.room_code = ?
      ORDER BY ir.created_at ASC`
   ).all(roomCode);
   return rows.map(r => ({
@@ -855,13 +858,13 @@ function cleanupOldDiagnostics(maxAgeDays = 30) {
 
 // --- Issue report helpers ---
 
-function createIssueReport(gameId, sessionId, autoDetected, deviceInfo) {
+function createIssueReport(gameId, sessionId, roomCode, autoDetected, deviceInfo) {
   const now = Date.now();
   const stmt = db.prepare(`
-    INSERT INTO issue_reports (game_id, session_id, auto_detected, device_info, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO issue_reports (game_id, session_id, room_code, auto_detected, device_info, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `);
-  const info = stmt.run(gameId || null, sessionId, autoDetected ? 1 : 0, JSON.stringify(deviceInfo || {}), now, now);
+  const info = stmt.run(gameId || null, sessionId, roomCode || null, autoDetected ? 1 : 0, JSON.stringify(deviceInfo || {}), now, now);
   return { id: info.lastInsertRowid, gameId, sessionId, autoDetected, createdAt: now };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.30.0000",
+  "version": "1.30.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/issues.js
+++ b/routes/issues.js
@@ -10,7 +10,7 @@ const {
 // POST /api/chess/issues — create a new issue report (flag a game)
 router.post('/issues', (req, res) => {
   try {
-    const { gameId, sessionId, autoDetected, deviceInfo } = req.body;
+    const { gameId, sessionId, roomCode, autoDetected, deviceInfo } = req.body;
 
     if (!sessionId) {
       return res.status(400).json({ error: 'sessionId is required' });
@@ -19,6 +19,7 @@ router.post('/issues', (req, res) => {
     const report = createIssueReport(
       gameId || null,
       sessionId,
+      roomCode || null,
       !!autoDetected,
       deviceInfo || {}
     );


### PR DESCRIPTION
## Summary
- Add `room_code` column to `issue_reports` table via runtime migration
- `getIssueReportsByRoomCode` now filters by `WHERE room_code = ?` directly instead of session_id subquery
- `createIssueReport` accepts and stores `room_code`
- `getDiagnosticsLobbyOnlyRooms` issue count uses the same direct `room_code` filter

## Root cause
Previously, issue reports were looked up by matching `session_id` against `diagnostic_events`. A player's `session_id` appears in `diagnostic_events` for every room they've joined, so their reports appeared in all those rooms — causing every room to show the same 3 reports.

## Test plan
- [ ] Start server, verify `issue_reports` table has `room_code` column after migration
- [ ] File an issue report from a room — confirm `room_code` is stored
- [ ] Check diagnostics for that room — only that room shows the report
- [ ] Check other rooms — they no longer show spurious reports