### PR TITLE
Fix stale issue reports when querying diagnostics by room code

### DIFF
--- a/db.js
+++ b/db.js
@@ -797,13 +797,26 @@ function getDiagnosticsLobbyOnlyRooms({ limit = 5 } = {}) {
 }
 
 function getIssueReportsByRoomCode(roomCode) {
-  const rows = db.prepare(
-    `SELECT ir.* FROM issue_reports ir
-     WHERE ir.session_id IN (
-       SELECT DISTINCT session_id FROM diagnostic_events WHERE room_code = ?
-     )
-     ORDER BY ir.created_at ASC`
-  ).all(roomCode);
+  // Scope to the most recent game in this room to avoid issues from old games bleeding in
+  const latestGame = db.prepare(
+    'SELECT MAX(game_id) as game_id FROM diagnostic_events WHERE room_code = ? AND game_id IS NOT NULL'
+  ).get(roomCode);
+
+  let rows;
+  if (latestGame?.game_id) {
+    rows = db.prepare(
+      `SELECT ir.* FROM issue_reports ir
+       WHERE ir.room_code = ? AND ir.game_id = ?
+       ORDER BY ir.created_at ASC`
+    ).all(roomCode, latestGame.game_id);
+  } else {
+    rows = db.prepare(
+      `SELECT ir.* FROM issue_reports ir
+       WHERE ir.room_code = ? AND ir.game_id IS NULL
+       ORDER BY ir.created_at ASC`
+    ).all(roomCode);
+  }
+
   return rows.map(r => ({
     ...r,
     categories: JSON.parse(r.categories || '[]'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.30.0000",
+  "version": "1.30.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {


### PR DESCRIPTION
## Problem
When viewing diagnostics via `?roomCode=X`, issue reports from previous games in the same room were appearing alongside current game issues. Room codes get reused, and the old query fetched all sessions ever associated with a room code.

## Fix
`getIssueReportsByRoomCode` now scopes to the most recent `game_id` for the room (found via `diagnostic_events`). Old game issues no longer bleed in.

## Changes
- `db.js`: Replace session-based subquery with game_id-scoped lookup