### PR TITLE
Fix stale issue reports for lobby-only rooms (timestamp scoping)

### DIFF
--- a/db.js
+++ b/db.js
@@ -797,7 +797,9 @@ function getDiagnosticsLobbyOnlyRooms({ limit = 5 } = {}) {
 }
 
 function getIssueReportsByRoomCode(roomCode) {
-  // Scope to the most recent game in this room to avoid issues from old games bleeding in
+  // Scope to the most recent session in this room to avoid issues from old sessions bleeding in.
+  // For rooms with a game, filter by the latest game_id.
+  // For lobby-only rooms, use the most recent lobby_created timestamp as the session boundary.
   const latestGame = db.prepare(
     'SELECT MAX(game_id) as game_id FROM diagnostic_events WHERE room_code = ? AND game_id IS NOT NULL'
   ).get(roomCode);
@@ -810,11 +812,30 @@ function getIssueReportsByRoomCode(roomCode) {
        ORDER BY ir.created_at ASC`
     ).all(roomCode, latestGame.game_id);
   } else {
-    rows = db.prepare(
-      `SELECT ir.* FROM issue_reports ir
-       WHERE ir.room_code = ? AND ir.game_id IS NULL
-       ORDER BY ir.created_at ASC`
-    ).all(roomCode);
+    // Lobby-only room: find when the current session started (most recent lobby_created)
+    const sessionStart = db.prepare(
+      `SELECT MAX(timestamp) as ts FROM diagnostic_events
+       WHERE room_code = ? AND event_type = 'lobby_created'`
+    ).get(roomCode);
+
+    if (sessionStart?.ts) {
+      rows = db.prepare(
+        `SELECT ir.* FROM issue_reports ir
+         WHERE ir.room_code = ? AND ir.created_at >= ?
+         ORDER BY ir.created_at ASC`
+      ).all(roomCode, sessionStart.ts);
+    } else {
+      // No lobby_created event — fall back to most recent 24h window
+      const latestActivity = db.prepare(
+        'SELECT MAX(timestamp) as ts FROM diagnostic_events WHERE room_code = ?'
+      ).get(roomCode);
+      const windowStart = latestActivity?.ts ? latestActivity.ts - 24 * 60 * 60 * 1000 : 0;
+      rows = db.prepare(
+        `SELECT ir.* FROM issue_reports ir
+         WHERE ir.room_code = ? AND ir.created_at >= ?
+         ORDER BY ir.created_at ASC`
+      ).all(roomCode, windowStart);
+    }
   }
 
   return rows.map(r => ({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.30.0001",
+  "version": "1.30.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {


### PR DESCRIPTION
## Problem
The previous fix (#45) scoped issue reports by game_id, but VXQ2Y4 is a lobby-only room where all events have `game_id = null`. Old stale issues from previous sessions kept appearing.

## Fix
For lobby-only rooms (no game_id), find the most recent `lobby_created` event timestamp and only show issue reports filed after that point. Falls back to a 24h window if no `lobby_created` event exists.

## Changes
- `db.js`: Add timestamp-based session scoping for lobby-only rooms