### PR TITLE
Public Lobbies

### DIFF
--- a/db.js
+++ b/db.js
@@ -217,6 +217,13 @@ function initDb() {
     CREATE INDEX IF NOT EXISTS idx_issue_reports_created_at ON issue_reports(created_at);
   `);
 
+  // Migration: add room_code column if not present
+  const irCols = db.prepare("PRAGMA table_info(issue_reports)").all().map(c => c.name);
+  if (!irCols.includes('room_code')) {
+    db.exec(`ALTER TABLE issue_reports ADD COLUMN room_code TEXT`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_issue_reports_room_code ON issue_reports(room_code)`);
+  }
+
   return db;
 }
 
@@ -777,9 +784,7 @@ function getDiagnosticsLobbyOnlyRooms({ limit = 5 } = {}) {
     `SELECT de.room_code, COUNT(de.id) as event_count,
             MIN(de.timestamp) as first_ts, MAX(de.timestamp) as last_ts,
             (SELECT COUNT(*) FROM issue_reports ir
-             WHERE ir.session_id IN (
-               SELECT DISTINCT session_id FROM diagnostic_events WHERE room_code = de.room_code
-             )) as issue_count
+             WHERE ir.room_code = de.room_code) as issue_count
      FROM diagnostic_events de
      WHERE de.game_id IS NULL AND de.room_code IS NOT NULL
      GROUP BY de.room_code
@@ -799,9 +804,7 @@ function getDiagnosticsLobbyOnlyRooms({ limit = 5 } = {}) {
 function getIssueReportsByRoomCode(roomCode) {
   const rows = db.prepare(
     `SELECT ir.* FROM issue_reports ir
-     WHERE ir.session_id IN (
-       SELECT DISTINCT session_id FROM diagnostic_events WHERE room_code = ?
-     )
+     WHERE ir.room_code = ?
      ORDER BY ir.created_at ASC`
   ).all(roomCode);
   return rows.map(r => ({
@@ -855,13 +858,13 @@ function cleanupOldDiagnostics(maxAgeDays = 30) {
 
 // --- Issue report helpers ---
 
-function createIssueReport(gameId, sessionId, autoDetected, deviceInfo) {
+function createIssueReport(gameId, sessionId, roomCode, autoDetected, deviceInfo) {
   const now = Date.now();
   const stmt = db.prepare(`
-    INSERT INTO issue_reports (game_id, session_id, auto_detected, device_info, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO issue_reports (game_id, session_id, room_code, auto_detected, device_info, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `);
-  const info = stmt.run(gameId || null, sessionId, autoDetected ? 1 : 0, JSON.stringify(deviceInfo || {}), now, now);
+  const info = stmt.run(gameId || null, sessionId, roomCode || null, autoDetected ? 1 : 0, JSON.stringify(deviceInfo || {}), now, now);
   return { id: info.lastInsertRowid, gameId, sessionId, autoDetected, createdAt: now };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.30.0000",
+  "version": "1.30.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.30.0001",
+  "version": "1.30.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -98,6 +98,7 @@ function createRoom(ws, sessionId, name, timeControl, camMode, chess960) {
     videoEnabled: effectiveCamMode !== 'none', // backward compat
     chess960: is960,
     creatorSessionId: sessionId,
+    isPublic: false,
   };
 
   rooms.set(roomId, room);
@@ -943,6 +944,40 @@ function handleReviewExit(sessionId) {
   }
 }
 
+/**
+ * Toggle public visibility for a waiting room.
+ * Only the room creator can change this, and only while in 'waiting' status.
+ */
+function setPublicRoom(sessionId, isPublic) {
+  const roomId = sessionRooms.get(sessionId);
+  if (!roomId) return { error: 'Not in a room' };
+  const room = rooms.get(roomId);
+  if (!room || room.status !== 'waiting') return { error: 'Room is not in waiting state' };
+  if (room.creatorSessionId !== sessionId) return { error: 'Only the room creator can change visibility' };
+  room.isPublic = !!isPublic;
+  return { ok: true, isPublic: room.isPublic };
+}
+
+/**
+ * List all public waiting rooms (for lobby discovery).
+ * Excludes the requesting session's own rooms.
+ */
+function listPublicRooms(excludeSessionId) {
+  const result = [];
+  for (const room of rooms.values()) {
+    if (room.status !== 'waiting' || !room.isPublic) continue;
+    if (excludeSessionId && room.creatorSessionId === excludeSessionId) continue;
+    result.push({
+      roomId: room.id,
+      timeControl: room.timeControl,
+      chess960: room.chess960,
+      hostName: room.white.name,
+      createdAt: room.createdAt,
+    });
+  }
+  return result;
+}
+
 module.exports = {
   createRoom,
   joinRoom,
@@ -969,5 +1004,7 @@ module.exports = {
   getRoomCount,
   listRoomsForSession,
   cancelRoom,
+  setPublicRoom,
+  listPublicRooms,
   sessionRooms,
 };

--- a/routes/issues.js
+++ b/routes/issues.js
@@ -10,7 +10,7 @@ const {
 // POST /api/chess/issues — create a new issue report (flag a game)
 router.post('/issues', (req, res) => {
   try {
-    const { gameId, sessionId, autoDetected, deviceInfo } = req.body;
+    const { gameId, sessionId, roomCode, autoDetected, deviceInfo } = req.body;
 
     if (!sessionId) {
       return res.status(400).json({ error: 'sessionId is required' });
@@ -19,6 +19,7 @@ router.post('/issues', (req, res) => {
     const report = createIssueReport(
       gameId || null,
       sessionId,
+      roomCode || null,
       !!autoDetected,
       deviceInfo || {}
     );

--- a/ws.js
+++ b/ws.js
@@ -126,6 +126,20 @@ function initWebSocket(server) {
           }
           break;
 
+        case 'set_public': {
+          const result = rooms.setPublicRoom(sessionId, !!payload?.isPublic);
+          if (result.error) {
+            send(ws, 'error', { message: result.error });
+          } else {
+            send(ws, 'public_set', { isPublic: result.isPublic });
+          }
+          break;
+        }
+
+        case 'list_public_rooms':
+          send(ws, 'public_rooms_list', { rooms: rooms.listPublicRooms(sessionId) });
+          break;
+
         // WebRTC video signaling — relay to opponent
         case 'rtc_offer':
         case 'rtc_answer':


### PR DESCRIPTION
## Summary

Add server-side support for public lobby discovery:

- `isPublic` field on room objects (default false)
- `setPublicRoom()` — lets room creator toggle visibility
- `listPublicRooms()` — returns waiting rooms marked as public
- WebSocket handlers for `set_public` and `list_public_rooms` messages

### Files changed (6 files, +95/-18)
- `rooms.js` — `isPublic` field, `setPublicRoom()`, `listPublicRooms()`
- `ws.js` — message handlers for `set_public` and `list_public_rooms`
- `db.js` — merged origin/main's scoped issue reports (conflict resolution)
- `routes/issues.js` — merged from main
- `package.json` — version bump
- `package-lock.json` — lockfile update

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-Public-Lobbies