### PR TITLE
fix: diagnostics pills most-recent-first with 24h stale fade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.31.0000",
+  "version": "1.31.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics-html.js
+++ b/routes/diagnostics-html.js
@@ -340,7 +340,9 @@ function renderGamesNav(recentGames, currentGameId, currentRoomCode) {
 
     const dots = status === 'ongoing' ? renderConnectionDots(g.sessionStates) : '';
     const pillBg = isCurrent ? colors.activeBg : colors.bg;
-    const inlineStyle = `background:${pillBg};border-color:${colors.border};color:${colors.text};`;
+    const isStale = (Date.now() - (g.lastTs || 0)) > 24 * 60 * 60 * 1000;
+    const opacityStyle = isStale ? 'opacity:0.5;' : '';
+    const inlineStyle = `background:${pillBg};border-color:${colors.border};color:${colors.text};${opacityStyle}`;
     const href = isRoom
       ? `/api/chess/diagnostics?roomCode=${encodeURIComponent(g.roomCode)}`
       : `/api/chess/diagnostics?gameId=${g.gameId}`;

--- a/routes/diagnostics.js
+++ b/routes/diagnostics.js
@@ -79,7 +79,8 @@ router.get('/diagnostics', (req, res) => {
         : g
     );
     const lobbyRooms = getDiagnosticsLobbyOnlyRooms();
-    const allNavEntries = [...recentGamesWithStates, ...lobbyRooms];
+    const allNavEntries = [...recentGamesWithStates, ...lobbyRooms]
+      .sort((a, b) => (b.lastTs || 0) - (a.lastTs || 0));
 
     const game = result.gameId ? getGame(result.gameId) : null;
     const issueReports = result.gameId


### PR DESCRIPTION
## Summary
- Sort all nav pills (games + lobby rooms) by `lastTs` descending — most recent game now appears first
- Pills older than 24 hours are faded at `opacity: 0.5`