### PR TITLE
Add logging to attemptLobbyReconnect for debugging mid-game resets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.31.0001",
+  "version": "1.31.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -299,6 +299,9 @@ function attemptLobbyReconnect(ws, sessionId, room) {
     return null;
   }
 
+  // Log lobby reconnection for debugging mid-game reset issues
+  console.log(`[rooms] attemptLobbyReconnect: session=${sessionId.slice(0, 8)} room=${room.id} side=${side} status=${room.status} moves=${room.moves?.length || 0}`);
+
   const player = getPlayerBySide(room, side);
   player.ws = ws;
   player.connected = true;


### PR DESCRIPTION
## Summary

Adds server-side diagnostic logging when `attemptLobbyReconnect` is called, to help debug scenarios where players get sent back to the lobby mid-game.

## Changes

- **rooms.js**: Added `console.log` in `attemptLobbyReconnect` with session, room, side, status, and move count
- **package.json**: Version bump 1.31.0001 → 1.31.0002

## Test plan

- [x] Server starts without errors
- [x] Logging output verified in server logs during lobby reconnect

Companion PR: https://github.com/bh679/chess-client/pull/143