### PR TITLE
refactor: extract DB migrations into migrations.js

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,5 +1,6 @@
 const Database = require('better-sqlite3');
 const path = require('path');
+const { runMigrations } = require('./migrations');
 
 const DB_PATH = path.join(__dirname, 'data', 'chess.db');
 
@@ -42,36 +43,6 @@ function initDb() {
     );
 
     CREATE INDEX IF NOT EXISTS idx_moves_game_id ON moves(game_id);
-  `);
-
-  // Migration: add engine columns for AI engine selection
-  try {
-    db.exec(`ALTER TABLE games ADD COLUMN white_engine TEXT`);
-  } catch (e) { /* column already exists */ }
-  try {
-    db.exec(`ALTER TABLE games ADD COLUMN black_engine TEXT`);
-  } catch (e) { /* column already exists */ }
-
-  // Migration: deduplicate existing moves and add unique constraint
-  // The UNIQUE constraint in CREATE TABLE only applies if the table is new.
-  // For existing tables, we need to create the index explicitly.
-  try {
-    // Remove duplicate moves keeping the one with the lowest rowid
-    db.exec(`
-      DELETE FROM moves WHERE id NOT IN (
-        SELECT MIN(id) FROM moves GROUP BY game_id, ply
-      )
-    `);
-    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_moves_game_ply ON moves(game_id, ply)`);
-  } catch (e) {
-    // Index may already exist; ignore
-  }
-
-  // Migration: normalize game results to chess notation
-  db.exec(`
-    UPDATE games SET result = '1-0' WHERE result = 'white';
-    UPDATE games SET result = '0-1' WHERE result = 'black';
-    UPDATE games SET result = '1/2-1/2' WHERE result = 'draw';
   `);
 
   // --- User accounts tables ---
@@ -145,37 +116,6 @@ function initDb() {
     );
   `);
 
-  // Migration: add user account columns to games table
-  try {
-    db.exec(`ALTER TABLE games ADD COLUMN white_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL`);
-  } catch (e) { /* column already exists */ }
-  try {
-    db.exec(`ALTER TABLE games ADD COLUMN black_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL`);
-  } catch (e) { /* column already exists */ }
-  try {
-    db.exec(`ALTER TABLE games ADD COLUMN white_rating_before REAL`);
-  } catch (e) { /* column already exists */ }
-  try {
-    db.exec(`ALTER TABLE games ADD COLUMN black_rating_before REAL`);
-  } catch (e) { /* column already exists */ }
-  try {
-    db.exec(`ALTER TABLE games ADD COLUMN white_rating_after REAL`);
-  } catch (e) { /* column already exists */ }
-  try {
-    db.exec(`ALTER TABLE games ADD COLUMN black_rating_after REAL`);
-  } catch (e) { /* column already exists */ }
-  try {
-    db.exec(`ALTER TABLE games ADD COLUMN rated INTEGER NOT NULL DEFAULT 0`);
-  } catch (e) { /* column already exists */ }
-
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_games_white_user ON games(white_user_id)`);
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_games_black_user ON games(black_user_id)`);
-
-  // Migration: add password_hash for local auth
-  try {
-    db.exec(`ALTER TABLE users ADD COLUMN password_hash TEXT`);
-  } catch (e) { /* column already exists */ }
-
   // --- Diagnostics table ---
   db.exec(`
     CREATE TABLE IF NOT EXISTS diagnostic_events (
@@ -217,12 +157,7 @@ function initDb() {
     CREATE INDEX IF NOT EXISTS idx_issue_reports_created_at ON issue_reports(created_at);
   `);
 
-  // Migration: add room_code column if not present
-  const irCols = db.prepare("PRAGMA table_info(issue_reports)").all().map(c => c.name);
-  if (!irCols.includes('room_code')) {
-    db.exec(`ALTER TABLE issue_reports ADD COLUMN room_code TEXT`);
-    db.exec(`CREATE INDEX IF NOT EXISTS idx_issue_reports_room_code ON issue_reports(room_code)`);
-  }
+  runMigrations(db);
 
   return db;
 }

--- a/migrations.js
+++ b/migrations.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * All schema migrations for chess-api.
+ *
+ * runMigrations(db) is idempotent — safe to call on every startup.
+ * Add new migrations at the end of the array; never reorder existing ones.
+ */
+
+const MIGRATIONS = [
+  {
+    name: 'add_engine_columns_to_games',
+    run(db) {
+      try {
+        db.exec(`ALTER TABLE games ADD COLUMN white_engine TEXT`);
+      } catch (e) { /* column already exists */ }
+      try {
+        db.exec(`ALTER TABLE games ADD COLUMN black_engine TEXT`);
+      } catch (e) { /* column already exists */ }
+    },
+  },
+  {
+    name: 'deduplicate_moves_and_add_unique_index',
+    run(db) {
+      try {
+        db.exec(`
+          DELETE FROM moves WHERE id NOT IN (
+            SELECT MIN(id) FROM moves GROUP BY game_id, ply
+          )
+        `);
+        db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_moves_game_ply ON moves(game_id, ply)`);
+      } catch (e) {
+        // Index may already exist or table may be empty; ignore
+      }
+    },
+  },
+  {
+    name: 'normalize_game_results',
+    run(db) {
+      db.exec(`
+        UPDATE games SET result = '1-0' WHERE result = 'white';
+        UPDATE games SET result = '0-1' WHERE result = 'black';
+        UPDATE games SET result = '1/2-1/2' WHERE result = 'draw';
+      `);
+    },
+  },
+  {
+    name: 'add_user_columns_to_games',
+    run(db) {
+      const cols = [
+        `ALTER TABLE games ADD COLUMN white_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL`,
+        `ALTER TABLE games ADD COLUMN black_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL`,
+        `ALTER TABLE games ADD COLUMN white_rating_before REAL`,
+        `ALTER TABLE games ADD COLUMN black_rating_before REAL`,
+        `ALTER TABLE games ADD COLUMN white_rating_after REAL`,
+        `ALTER TABLE games ADD COLUMN black_rating_after REAL`,
+        `ALTER TABLE games ADD COLUMN rated INTEGER NOT NULL DEFAULT 0`,
+      ];
+      for (const sql of cols) {
+        try { db.exec(sql); } catch (e) { /* column already exists */ }
+      }
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_games_white_user ON games(white_user_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_games_black_user ON games(black_user_id)`);
+    },
+  },
+  {
+    name: 'add_password_hash_to_users',
+    run(db) {
+      try {
+        db.exec(`ALTER TABLE users ADD COLUMN password_hash TEXT`);
+      } catch (e) { /* column already exists */ }
+    },
+  },
+  {
+    name: 'add_room_code_to_issue_reports',
+    run(db) {
+      const cols = db.prepare('PRAGMA table_info(issue_reports)').all().map(c => c.name);
+      if (!cols.includes('room_code')) {
+        db.exec(`ALTER TABLE issue_reports ADD COLUMN room_code TEXT`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_issue_reports_room_code ON issue_reports(room_code)`);
+      }
+    },
+  },
+];
+
+function runMigrations(db) {
+  const migrate = db.transaction(() => {
+    for (const migration of MIGRATIONS) {
+      migration.run(db);
+      console.log(`[migrations] ran: ${migration.name}`);
+    }
+  });
+  migrate();
+}
+
+module.exports = { runMigrations };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.34.0000",
+  "version": "1.34.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {


### PR DESCRIPTION
## Summary
- Extracts all `ALTER TABLE` migration blocks from `initDb()` in `db.js` into a new `migrations.js` module
- `runMigrations(db)` runs all 6 named migrations in a single transaction on every startup — idempotent and safe
- Each migration logs its name to console so startup output shows which migrations ran
- `db.js` `initDb()` now only contains base `CREATE TABLE IF NOT EXISTS` statements + a `runMigrations(db)` call

## Files changed
- **`migrations.js`** (new, +96 lines) — 6 named migrations: engine columns, move dedup/unique index, result normalization, user columns on games, password_hash on users, room_code on issue_reports
- **`db.js`** (-68 lines) — removed all migration blocks, added `require('./migrations')` and `runMigrations(db)` call
- **`package.json`** — version bumped to `1.34.0001`

## Test plan
- [x] Fresh DB: all 6 migrations ran, all tables/columns/indexes verified
- [x] Second startup (idempotency): all migrations ran without error, schema intact
- [x] Health check: `GET /api/chess/health` → `{"status":"ok","version":"1.34.0001"}`