### PR TITLE
feat: add input validation to route handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chess-api",
-  "version": "1.30.0002",
+  "version": "1.35.0001",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-api",
-      "version": "1.30.0002",
+      "version": "1.35.0001",
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.35.0000",
+  "version": "1.35.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/diagnostics.js
+++ b/routes/diagnostics.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const { validateRoomCode } = require('../validation');
 const {
   insertDiagnosticEvents,
   getDiagnosticsByGame,
@@ -24,6 +25,10 @@ router.post('/diagnostics', (req, res) => {
 
     if (!sessionId || !Array.isArray(events) || events.length === 0) {
       return res.status(400).json({ error: 'sessionId and non-empty events array required' });
+    }
+    if (roomCode) {
+      const rcCheck = validateRoomCode(roomCode);
+      if (!rcCheck.valid) return res.status(400).json({ error: rcCheck.error });
     }
 
     const batch = events.slice(0, MAX_BATCH_SIZE);

--- a/routes/game-history.js
+++ b/routes/game-history.js
@@ -1,12 +1,15 @@
 const express = require('express');
 const { listGamesByUser, claimGame, getGame, updatePlayerName } = require('../db');
 const { requireAuth } = require('../middleware/auth');
+const { validatePagination } = require('../validation');
 
 const router = express.Router();
 
 // GET /api/my-games — authenticated user's game history
 router.get('/my-games', requireAuth, (req, res) => {
   const { limit, offset, category, result, opponent } = req.query;
+  const pageCheck = validatePagination(offset, limit);
+  if (!pageCheck.valid) return res.status(400).json({ error: pageCheck.error });
   const data = listGamesByUser(req.user.id, {
     limit: parseInt(limit) || 15,
     offset: parseInt(offset) || 0,

--- a/routes/games.js
+++ b/routes/games.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const db = require('../db');
 const { optionalAuth } = require('../middleware/auth');
+const { validateFEN, validateSAN, validateTimeControl, validatePagination } = require('../validation');
 
 // POST /api/games — Create a new game
 router.post('/games', optionalAuth, (req, res) => {
@@ -9,6 +10,12 @@ router.post('/games', optionalAuth, (req, res) => {
     const { gameType, timeControl, startingFen, white, black } = req.body;
     if (!startingFen || !white || !black) {
       return res.status(400).json({ error: 'Missing required fields' });
+    }
+    const fenCheck = validateFEN(startingFen);
+    if (!fenCheck.valid) return res.status(400).json({ error: fenCheck.error });
+    if (timeControl !== undefined && timeControl !== null) {
+      const tcCheck = validateTimeControl(timeControl);
+      if (!tcCheck.valid) return res.status(400).json({ error: tcCheck.error });
     }
     // If logged in, set player name and link user to non-AI sides
     if (req.user) {
@@ -35,6 +42,10 @@ router.post('/games/:id/moves', (req, res) => {
     if (san === undefined || fen === undefined) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
+    const sanCheck = validateSAN(san);
+    if (!sanCheck.valid) return res.status(400).json({ error: sanCheck.error });
+    const fenCheck = validateFEN(fen);
+    if (!fenCheck.valid) return res.status(400).json({ error: fenCheck.error });
     const inserted = db.addMove(gameId, { ply, san, fen, timestamp, side });
     res.status(inserted ? 204 : 409).end();
   } catch (e) {
@@ -100,6 +111,8 @@ router.post('/games/list', (req, res) => {
     if (!Array.isArray(ids)) {
       return res.status(400).json({ error: 'ids must be an array' });
     }
+    const pageCheck = validatePagination(offset, limit);
+    if (!pageCheck.valid) return res.status(400).json({ error: pageCheck.error });
     // Sanitize: only allow positive integers
     const cleanIds = ids.filter(id => Number.isInteger(id) && id > 0);
     const result = db.listGames(cleanIds, limit, offset);
@@ -114,6 +127,8 @@ router.post('/games/list', (req, res) => {
 router.post('/games/list-all', (req, res) => {
   try {
     const { limit = 15, offset = 0 } = req.body || {};
+    const pageCheck = validatePagination(offset, limit);
+    if (!pageCheck.valid) return res.status(400).json({ error: pageCheck.error });
     const result = db.listAllGames(limit, offset);
     res.json(result);
   } catch (e) {

--- a/routes/issues.js
+++ b/routes/issues.js
@@ -6,6 +6,7 @@ const {
   getIssueReportByGame,
   getIssueReport,
 } = require('../db');
+const { validateRoomCode } = require('../validation');
 
 // POST /api/chess/issues — create a new issue report (flag a game)
 router.post('/issues', (req, res) => {
@@ -14,6 +15,10 @@ router.post('/issues', (req, res) => {
 
     if (!sessionId) {
       return res.status(400).json({ error: 'sessionId is required' });
+    }
+    if (roomCode) {
+      const rcCheck = validateRoomCode(roomCode);
+      if (!rcCheck.valid) return res.status(400).json({ error: rcCheck.error });
     }
 
     const report = createIssueReport(

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { getUserByUsername, updateUser, formatUser, getRatings, getRatingHistory, listGamesByUser } = require('../db');
 const { requireAuth, optionalAuth } = require('../middleware/auth');
+const { validatePagination } = require('../validation');
 
 const router = express.Router();
 
@@ -33,6 +34,8 @@ router.get('/users/:username/games', optionalAuth, (req, res) => {
   }
 
   const { limit, offset, category, result, opponent, gameType, playerType, timeControl, eloMin, eloMax } = req.query;
+  const pageCheck = validatePagination(offset, limit);
+  if (!pageCheck.valid) return res.status(400).json({ error: pageCheck.error });
   const data = listGamesByUser(user.id, {
     limit: parseInt(limit) || 15,
     offset: parseInt(offset) || 0,
@@ -75,6 +78,8 @@ router.get('/users/:username/rating-history', optionalAuth, (req, res) => {
   if (!category) {
     return res.status(400).json({ error: 'Category query parameter is required' });
   }
+  const pageCheck = validatePagination(undefined, limit);
+  if (!pageCheck.valid) return res.status(400).json({ error: pageCheck.error });
 
   const history = getRatingHistory(user.id, category, parseInt(limit) || 50, 0);
   res.json(history.map(h => ({

--- a/validation.js
+++ b/validation.js
@@ -1,0 +1,102 @@
+'use strict';
+
+/**
+ * Reusable input validators for chess-api route handlers.
+ * Each validator returns { valid: true } or { valid: false, error: '<message>' }.
+ */
+
+/**
+ * Room code: exactly 6 alphanumeric characters.
+ */
+function validateRoomCode(code) {
+  if (typeof code !== 'string') {
+    return { valid: false, error: 'roomCode must be a string' };
+  }
+  if (!/^[A-Za-z0-9]{6}$/.test(code)) {
+    return { valid: false, error: 'roomCode must be exactly 6 alphanumeric characters' };
+  }
+  return { valid: true };
+}
+
+/**
+ * SAN (Standard Algebraic Notation): basic structural check.
+ * Accepts moves like e4, Nf3, O-O, O-O-O, exd5, Qxh7+, e8=Q#, etc.
+ */
+function validateSAN(san) {
+  if (typeof san !== 'string') {
+    return { valid: false, error: 'san must be a string' };
+  }
+  if (san.length === 0 || san.length > 10) {
+    return { valid: false, error: 'san must be between 1 and 10 characters' };
+  }
+  // Castling
+  if (/^O-O(-O)?[+#]?$/.test(san)) return { valid: true };
+  // Standard piece move / pawn move
+  if (!/^[KQRBN]?[a-h]?[1-8]?x?[a-h][1-8](=[QRBN])?[+#]?$/.test(san)) {
+    return { valid: false, error: `"${san}" is not a valid SAN move` };
+  }
+  return { valid: true };
+}
+
+/**
+ * Time control: "N+N" (minutes + increment) or "N/N+N" (odds format).
+ * N is a non-negative integer.
+ */
+function validateTimeControl(tc) {
+  if (typeof tc !== 'string') {
+    return { valid: false, error: 'timeControl must be a string' };
+  }
+  if (!/^\d+\/\d+\+\d+$/.test(tc) && !/^\d+\+\d+$/.test(tc)) {
+    return { valid: false, error: 'timeControl must be in "N+N" or "N/N+N" format (e.g. "5+3" or "2/5+0")' };
+  }
+  return { valid: true };
+}
+
+/**
+ * FEN: basic structure check — 6 space-separated fields, first field has 8 ranks.
+ */
+function validateFEN(fen) {
+  if (typeof fen !== 'string') {
+    return { valid: false, error: 'fen must be a string' };
+  }
+  const parts = fen.trim().split(/\s+/);
+  if (parts.length < 4 || parts.length > 6) {
+    return { valid: false, error: 'fen must have 4-6 space-separated fields' };
+  }
+  const ranks = parts[0].split('/');
+  if (ranks.length !== 8) {
+    return { valid: false, error: 'fen position field must have 8 ranks separated by "/"' };
+  }
+  // Each rank should contain only valid FEN characters
+  const validRank = /^[pPnNbBrRqQkK1-8]+$/;
+  for (const rank of ranks) {
+    if (!validRank.test(rank)) {
+      return { valid: false, error: `fen contains invalid rank data: "${rank}"` };
+    }
+  }
+  return { valid: true };
+}
+
+/**
+ * Pagination: page/offset and limit must be non-negative integers, limit <= 100.
+ * Pass raw query/body values (strings or numbers); they will be coerced.
+ */
+function validatePagination(page, limit) {
+  const p = parseInt(page, 10);
+  const l = parseInt(limit, 10);
+
+  if (page !== undefined && page !== null && (isNaN(p) || p < 0)) {
+    return { valid: false, error: 'offset/page must be a non-negative integer' };
+  }
+  if (limit !== undefined && limit !== null) {
+    if (isNaN(l) || l < 1) {
+      return { valid: false, error: 'limit must be a positive integer' };
+    }
+    if (l > 100) {
+      return { valid: false, error: 'limit must not exceed 100' };
+    }
+  }
+  return { valid: true };
+}
+
+module.exports = { validateRoomCode, validateSAN, validateTimeControl, validateFEN, validatePagination };


### PR DESCRIPTION
## Summary

- Add `validation.js` with 5 reusable validators: `validateRoomCode`, `validateSAN`, `validateTimeControl`, `validateFEN`, `validatePagination`
- Apply validators at the entry points of all route handlers that accept user input
- Return 400 with descriptive error messages on validation failure; no business logic changed

## Test plan

- [x] `POST /games` — rejects invalid FEN and malformed timeControl with 400
- [x] `POST /games/:id/moves` — rejects invalid SAN and invalid FEN with 400
- [x] `POST /games/list` and `POST /games/list-all` — rejects limit > 100 with 400
- [x] `POST /issues` — rejects malformed roomCode with 400
- [x] `POST /diagnostics` — rejects malformed roomCode with 400
- [x] `GET /users/:username/games` and `GET /my-games` — rejects limit > 100 with 400
- [x] All valid requests continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)