### PR TITLE
Include camMode in public rooms list response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chess-api",
-  "version": "1.35.0001",
+  "version": "1.36.0001",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-api",
-      "version": "1.35.0001",
+      "version": "1.36.0001",
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.36.0000",
+  "version": "1.36.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -987,6 +987,7 @@ function listPublicRooms(excludeSessionId) {
       roomId: room.id,
       timeControl: room.timeControl,
       chess960: room.chess960,
+      camMode: room.camMode,
       hostName: room.white.name,
       createdAt: room.createdAt,
     });


### PR DESCRIPTION
## Summary
- `listPublicRooms()` now includes `camMode` in each room entry so the client can display it

## Test plan
- [ ] Verify `camMode` field appears in the `public_rooms_list` WebSocket response