### PR TITLE
Fix duplicate video_start broadcasts in lobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.37.0000",
+  "version": "1.37.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -838,6 +838,7 @@ function handleVideoReady(sessionId) {
   const side = getPlayerSide(room, sessionId);
   if (!side) return;
   const player = getPlayerBySide(room, side);
+  if (player.videoReady) return;
   player.videoReady = true;
   const opponent = getPlayerBySide(room, side === 'w' ? 'b' : 'w');
   if (opponent && opponent.videoReady) {


### PR DESCRIPTION
## Summary
- Add guard in `handleVideoReady()` to return early if player is already `videoReady`
- Prevents duplicate `video_start` signals that cause WebRTC SDP state errors and ICE failures in the lobby

## Test plan
- [x] WebSocket test: duplicate `video_ready` only produces 1 `video_start`
- [ ] Manual test: two devices join lobby, video connects first attempt

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-Video-Lobby-Fix