### PR TITLE
Remove /dashboard server route

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,13 +54,6 @@ app.use('/api/chess', iceServersRouter);
 app.use('/api/chess', diagnosticsRouter);
 app.use('/api/chess', issuesRouter);
 
-// Serve dashboard.html for /dashboard route
-if (process.env.CLIENT_DIR) {
-  app.get('/dashboard', (req, res) => {
-    res.sendFile(path.resolve(process.env.CLIENT_DIR, 'dashboard.html'));
-  });
-}
-
 // SPA catch-all: serve index.html for non-API, non-static paths
 // This allows path-based URLs (/replay, /games) to load the app,
 // which then redirects to the hash equivalent (/#/replay, /#/games)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.37.0001",
+  "version": "1.38.0000",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.37.0000",
+  "version": "1.37.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {


### PR DESCRIPTION
## Summary
- Remove the `/dashboard` server route from `index.js`
- Dashboard is now served as a static file directly (`dashboard.html`), so the explicit route is unnecessary

## Changes
- `index.js`: Removed 6 lines (the `/dashboard` route handler)

## Test plan
- [x] `/dashboard` path now falls through to SPA catch-all (serves index.html)
- [x] Dashboard accessible at `dashboard.html` via static file serving

Wiki: https://github.com/bh679/chess-client/wiki/Feature:-Diagnostics-Dashboard