### PR TITLE
Fix: cancelRoom now handles lobby-status rooms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.38.0000",
+  "version": "1.38.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -808,8 +808,22 @@ function cancelRoom(sessionId) {
   if (!roomId) return false;
 
   const room = rooms.get(roomId);
-  if (!room || room.status !== 'waiting') return false;
-  if (room.white.sessionId !== sessionId) return false;
+  if (!room) return false;
+
+  // Allow cancelling waiting rooms (by creator) and lobby rooms (by either player)
+  if (room.status === 'waiting') {
+    if (room.white.sessionId !== sessionId) return false;
+  } else if (room.status === 'lobby') {
+    const side = getPlayerSide(room, sessionId);
+    if (!side) return false;
+    // Notify the other player before cleanup
+    const opponent = getPlayerBySide(room, side === 'w' ? 'b' : 'w');
+    if (opponent && opponent.ws) {
+      send(opponent.ws, 'room_cancelled', {});
+    }
+  } else {
+    return false;
+  }
 
   cleanupRoom(roomId);
   return true;


### PR DESCRIPTION
## Summary
- Extended `cancelRoom()` to handle both `waiting` and `lobby` status rooms
- Previously, cancelling a lobby room was silently ignored, leaving the room alive for auto-reconnection
- Now notifies the opponent before cleanup when cancelling a lobby room
- Companion PR in chess-client sends `cancel_room` on exit

## Changes
- `rooms.js`: Updated `cancelRoom()` function to accept `lobby` status rooms and notify opponent (lines 806-826)

## Test plan
- [x] Playwright: Verify full disconnect flow with updated server
- [ ] Manual: Create lobby with 2 players → one exits → other receives `room_cancelled`

Wiki: https://github.com/bh679/chess-api/wiki/Feature:-Exit-Game-Disconnect