### PR TITLE
feat: TURN usage monitoring endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-try { process.loadEnvFile(); } catch (_) {}
+try { process.loadEnvFile(require('path').join(__dirname, '.env')); } catch (_) {}
 const http = require('http');
 const express = require('express');
 const path = require('path');

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+try { process.loadEnvFile(); } catch (_) {}
 const http = require('http');
 const express = require('express');
 const path = require('path');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chess-api",
-  "version": "1.36.0001",
+  "version": "1.39.0000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-api",
-      "version": "1.36.0001",
+      "version": "1.39.0000",
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.39.0002",
+  "version": "1.39.0003",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.39.0001",
+  "version": "1.39.0002",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.39.0000",
+  "version": "1.39.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/routes/ice-servers.js
+++ b/routes/ice-servers.js
@@ -176,7 +176,18 @@ router.get('/turn-usage', async (req, res) => {
       return res.json({ available: false, error: `Metered API error: ${response.status}` });
     }
     const data = await response.json();
-    return res.json({ available: true, usageInGB: data.usageInGB, quotaInGB: data.quotaInGB, overageInGB: data.overageInGB });
+
+    // Calculate next reset date if METERED_BILLING_DAY is set (day of month, 1-28)
+    let nextResetDate = null;
+    const billingDay = parseInt(process.env.METERED_BILLING_DAY, 10);
+    if (billingDay >= 1 && billingDay <= 28) {
+      const now = new Date();
+      const thisMonth = new Date(now.getFullYear(), now.getMonth(), billingDay);
+      const nextReset = now.getDate() < billingDay ? thisMonth : new Date(now.getFullYear(), now.getMonth() + 1, billingDay);
+      nextResetDate = nextReset.toISOString().slice(0, 10); // YYYY-MM-DD
+    }
+
+    return res.json({ available: true, usageInGB: data.usageInGB, quotaInGB: data.quotaInGB, overageInGB: data.overageInGB, nextResetDate });
   } catch (err) {
     console.warn('[turn-usage] Fetch failed:', err.message);
     return res.json({ available: false, error: err.message });

--- a/routes/ice-servers.js
+++ b/routes/ice-servers.js
@@ -156,4 +156,31 @@ router.get('/ice-servers', async (req, res) => {
   });
 });
 
+// GET /api/chess/turn-usage — returns Metered.ca TURN bandwidth usage for the current billing cycle.
+// Returns { available: false } if not configured or on API error (never errors the dashboard).
+router.get('/turn-usage', async (req, res) => {
+  const domain = process.env.METERED_DOMAIN;
+  const secretKey = process.env.METERED_SECRET_KEY;
+
+  if (!domain || !secretKey) {
+    return res.json({ available: false });
+  }
+
+  try {
+    // Domain may be a bare app name (e.g. "myapp") or a full hostname (e.g. "myapp.metered.live")
+    const host = domain.includes('.') ? domain : `${domain}.metered.live`;
+    const url = `https://${host}/api/v1/turn/current_usage?secretKey=${secretKey}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.warn(`[turn-usage] Metered API error: ${response.status} ${response.statusText}`);
+      return res.json({ available: false, error: `Metered API error: ${response.status}` });
+    }
+    const data = await response.json();
+    return res.json({ available: true, usageInGB: data.usageInGB, quotaInGB: data.quotaInGB, overageInGB: data.overageInGB });
+  } catch (err) {
+    console.warn('[turn-usage] Fetch failed:', err.message);
+    return res.json({ available: false, error: err.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary

- New `GET /api/chess/turn-usage` endpoint fetches real-time bandwidth usage from the Metered.ca API
- Returns `{ available, usageInGB, quotaInGB, overageInGB, nextResetDate }` — falls back to `{ available: false }` gracefully if unconfigured or on any error
- Reads `METERED_DOMAIN`, `METERED_SECRET_KEY`, `METERED_BILLING_DAY` from environment
- Added `process.loadEnvFile(__dirname + '/.env')` in `index.js` for local dev secret loading

## Test plan
- [ ] `curl /api/chess/turn-usage` with valid env returns `available: true` with usage stats
- [ ] Without env vars set, returns `{ "available": false }`
- [ ] On Metered API error, returns `{ "available": false }` (no 500)