### PR TITLE
Assign colors at game start based on colorPreference setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-api",
-  "version": "1.41.0000",
+  "version": "1.41.0001",
   "private": true,
   "description": "REST API for chess game storage",
   "scripts": {

--- a/rooms.js
+++ b/rooms.js
@@ -267,6 +267,18 @@ function handlePlayerReady(sessionId, ready) {
 function startGameFromLobby(room) {
   room.status = 'playing';
 
+  // Reassign colors based on colorPreference at game start
+  const creatorIsCurrentlyWhite = room.white.sessionId === room.creatorSessionId;
+  const pref = room.colorPreference ?? 'random';
+  const creatorShouldBeWhite = pref === 'white' ? true
+    : pref === 'black' ? false
+    : Math.random() < 0.5;
+  if (creatorIsCurrentlyWhite !== creatorShouldBeWhite) {
+    const tmp = room.white;
+    room.white = room.black;
+    room.black = tmp;
+  }
+
   // Map creator/opponent clock times to w/b based on which color the creator was assigned
   if (room.clocks) {
     const creatorIsWhite = room.white.sessionId === room.creatorSessionId;


### PR DESCRIPTION
## Summary

- Colors are now assigned in startGameFromLobby rather than when the opponent joins
- Respects room.colorPreference: 'white' gives creator white, 'black' gives creator black, 'random' randomises at game start

## Test plan

- [ ] Set color preference to White in lobby, start game — verify you are White
- [ ] Set color preference to Black in lobby, start game — verify you are Black
- [ ] Set color preference to Random, start game — verify color is randomised