### PR TITLE
Fix tile-cam server-side validation

### DIFF
--- a/matchmaking.js
+++ b/matchmaking.js
@@ -7,7 +7,7 @@ const DEFAULT_TC = '5+0';
 
 function joinQueue(ws, sessionId, name, timeControl, camMode, chess960) {
   const tc = timeControl || DEFAULT_TC;
-  const effectiveCamMode = ['none', 'king-cam', 'board-face', 'split-cam'].includes(camMode) ? camMode : 'none';
+  const effectiveCamMode = ['none', 'king-cam', 'board-face', 'tile-cam', 'split-cam', 'split-cam-h'].includes(camMode) ? camMode : 'none';
   const wantsVideo = effectiveCamMode !== 'none';
 
   // Check if already in a queue

--- a/rooms.js
+++ b/rooms.js
@@ -79,7 +79,7 @@ function createRoom(ws, sessionId, name, timeControl, camMode, chess960) {
 
   const is960 = !!chess960;
   const startFen = is960 ? generateChess960FEN() : undefined;
-  const effectiveCamMode = ['none', 'king-cam', 'board-face', 'split-cam', 'split-cam-h'].includes(camMode) ? camMode : 'none';
+  const effectiveCamMode = ['none', 'king-cam', 'board-face', 'tile-cam', 'split-cam', 'split-cam-h'].includes(camMode) ? camMode : 'none';
 
   const room = {
     id: roomId,
@@ -208,7 +208,7 @@ function handleSettingChange(sessionId, field, value) {
     room.white = { ...oldBlack };
     room.black = { ...oldWhite };
   } else if (field === 'camMode') {
-    const validCamModes = ['none', 'king-cam', 'board-face', 'split-cam', 'split-cam-h'];
+    const validCamModes = ['none', 'king-cam', 'board-face', 'tile-cam', 'split-cam', 'split-cam-h'];
     if (validCamModes.includes(value)) {
       room.camMode = value;
       room.videoEnabled = value !== 'none';


### PR DESCRIPTION
## Summary
- Add `tile-cam` to valid cam mode whitelists in `rooms.js` (room creation and setting change handler)
- Add `tile-cam` and `split-cam-h` to valid cam modes in `matchmaking.js`
- Without this fix, selecting tile-cam in the lobby was silently rejected by the server, resetting back to board-face

## Test plan
- [ ] Create a room with tile-cam mode selected
- [ ] Switch cam mode to tile-cam in lobby — verify it persists
- [ ] Quick match with tile-cam — verify it's accepted